### PR TITLE
Switch DNS resolution to prefer IPv4 in tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,19 +95,19 @@ jobs:
       run: "cd smoke_test/workers && npm link ../.."
 
     - name: "Local test with Hrana 1 over WebSocket"
-      run: "cd smoke_test/workers && python ../../hrana-test-server/server_v1.py node test.js"
+      run: "cd smoke_test/workers && python ../../hrana-test-server/server_v1.py node --dns-result-order=ipv4first test.js"
       env: {"LOCAL": "1", "URL": "ws://localhost:8080"}
     - name: "Local test with Hrana 2 over WebSocket"
-      run: "cd smoke_test/workers && python ../../hrana-test-server/server_v2.py node test.js"
+      run: "cd smoke_test/workers && python ../../hrana-test-server/server_v2.py node --dns-result-order=ipv4first test.js"
       env: {"LOCAL": "1", "URL": "ws://localhost:8080"}
     - name: "Local test with Hrana 2 over HTTP"
-      run: "cd smoke_test/workers && python ../../hrana-test-server/server_v2.py node test.js"
+      run: "cd smoke_test/workers && python ../../hrana-test-server/server_v2.py node --dns-result-order=ipv4first test.js"
       env: {"LOCAL": "1", "URL": "http://localhost:8080"}
 #    - name: "Local test with Hrana 3 over WebSocket"
-#      run: "cd smoke_test/workers && python ../../hrana-test-server/server_v3.py node test.js"
+#      run: "cd smoke_test/workers && python ../../hrana-test-server/server_v3.py node --dns-result-order=ipv4first test.js"
 #      env: {"LOCAL": "1", "URL": "ws://localhost:8080"}
 #    - name: "Local test with Hrana 3 over HTTP"
-#      run: "cd smoke_test/workers && python ../../hrana-test-server/server_v3.py node test.js"
+#      run: "cd smoke_test/workers && python ../../hrana-test-server/server_v3.py node --dns-result-order=ipv4first test.js"
 #      env: {"LOCAL": "1", "URL": "http://localhost:8080"}
 
     # - name: "Non-local test with Hrana 1 over WebSocket"


### PR DESCRIPTION
In the Cloudflare Workers local tests, Node seems to prefer resolving to IPv6, but the Wrangler server is only listening to IPv4, which results in "connection refused" errors. Fix the problem by forcing Node to prefer IPv4 for DNS resolution.