### PR TITLE
Next.js build fails due to this regex

### DIFF
--- a/packages/libsql-core/src/uri.ts
+++ b/packages/libsql-core/src/uri.ts
@@ -90,7 +90,7 @@ const AUTHORITY_RE = (() => {
     const USERINFO = '(?<username>[^:]*)(:(?<password>.*))?';
     const HOST = '((?<host>[^:\\[\\]]*)|(\\[(?<host_br>[^\\[\\]]*)\\]))';
     const PORT = '(?<port>[0-9]*)';
-    return new RegExp(`^(${USERINFO}@)?${HOST}(:${PORT})?$`, "su");
+    return new RegExp("^(" + USERINFO + "@)?" + HOST + "(:" + PORT + ")?$", "su");
 })();
 
 // Query string is parsed as application/x-www-form-urlencoded according to the Web URL standard:


### PR DESCRIPTION
Next.js build fails when you upgrade to `14.0.3+` versions.

Upon searching I found this issue in next.js repo - https://github.com/vercel/next.js/issues/59540
which points that a regex change which fixes the build issue. 

In the latest version of libsql-client-ts `0.4.0-pre.10`, the fix has been implemented, 
but,
- some weirdness with string literals and regex parsing OR 
- how next.js build process(rust) parses this lib OR 
- voodoo magic 

Fails the build with a Collecting Page Data error.

Using a string concatenation solves this.

Also, tagging another issue from this repo 
- https://github.com/tursodatabase/libsql-client-ts/issues/142

Fixes #142 
Fixes vercel/next.js#59540 