### PR TITLE
fix: Do not make rows read-only

### DIFF
--- a/packages/libsql-client-wasm/src/wasm.ts
+++ b/packages/libsql-client-wasm/src/wasm.ts
@@ -288,7 +288,7 @@ function rowFromSql(sqlRow: Array<unknown>, columns: Array<string>, intMode: Int
 
         const column = columns[i];
         if (!Object.hasOwn(row, column)) {
-            Object.defineProperty(row, column, { value, enumerable: true });
+            Object.defineProperty(row, column, { value, enumerable: true, configurable: true, writable: true });
         }
     }
     return row as Row;

--- a/packages/libsql-client/src/sqlite3.ts
+++ b/packages/libsql-client/src/sqlite3.ts
@@ -270,7 +270,7 @@ function rowFromSql(sqlRow: Array<unknown>, columns: Array<string>, intMode: Int
 
         const column = columns[i];
         if (!Object.hasOwn(row, column)) {
-            Object.defineProperty(row, column, { value, enumerable: true });
+            Object.defineProperty(row, column, { value, enumerable: true, configurable: true, writable: true });
         }
     }
     return row as Row;


### PR DESCRIPTION
Since `Object.defineProperty` defaults to `configurable: false` and `writable: false`, all row objects created in libsql-client currently have read-only columns.
Irrespective of our opinions on immutability, this behavior is unfortunately not backward-compatible with any of the other sqlite JS/TS clients.

[I started implementing a libSQL driver in TypeORM](https://github.com/typeorm/typeorm/pull/10662), but the tests are currently failing because of fields on row objects being read-only.