### PR TITLE
libsql-client-wasm: Use bundled dependencies

### DIFF
--- a/packages/libsql-client-wasm/package.json
+++ b/packages/libsql-client-wasm/package.json
@@ -22,6 +22,7 @@
     ],
     "license": "MIT",
     "type": "module",
+    "bundledDependencies": ["@libsql/libsql-wasm-experimental"],
     "main": "lib-esm/wasm.js",
     "types": "lib-esm/wasm.d.ts",
     "exports": {


### PR DESCRIPTION
Switch to use bundled dependencies in the package to make the package a drop-in replacement as a polyfill for `@libsql/client`.