### PR TITLE
libsql-client-wasm: Fix bundled dependencies

### DIFF
--- a/packages/libsql-client-wasm/package.json
+++ b/packages/libsql-client-wasm/package.json
@@ -45,9 +45,10 @@
     ],
     "scripts": {
         "prepublishOnly": "npm run build",
-        "prebuild": "rm -rf ./lib-esm",
+        "prebuild": "rm -rf ./lib-esm && npm run bundle",
         "build": "npm run build:esm",
         "build:esm": "tsc -p tsconfig.build-esm.json",
+        "bundle": "rm -rf node_modules && mkdir -p node_modules/@libsql/libsql-wasm-experimental && cp -R ../../node_modules/@libsql/libsql-wasm-experimental/* node_modules/@libsql/libsql-wasm-experimental",
         "test": "jest --runInBand",
         "typecheck": "tsc --noEmit",
         "typedoc": "rm -rf ./docs && typedoc"


### PR DESCRIPTION
As it turns out, `npm` does not actually bundle dependencies if you're using workspace...

https://github.com/npm/cli/issues/3466

Let's work around that by manually copying `node_modules` in pre-build step.