### PR TITLE
libsql-client: Make libsql dependency optional

### DIFF
--- a/packages/libsql-client/package.json
+++ b/packages/libsql-client/package.json
@@ -101,7 +101,9 @@
     "dependencies": {
         "@libsql/core": "^0.4.2",
         "@libsql/hrana-client": "^0.5.6",
-        "js-base64": "^3.7.5",
+        "js-base64": "^3.7.5"
+    },
+    "optionalDependencies": {
         "libsql": "^0.2.0"
     },
     "devDependencies": {


### PR DESCRIPTION
The `@libsql/client` can be used even without the `libsql` package. So make the `libsql` dependency optional if no native package is found. This happens, for example, with StackBlitz, which is wasm32 environment.