### PR TITLE
Inline regex variables in regex constructor to avoid Next.js errors

### DIFF
--- a/packages/libsql-core/src/uri.ts
+++ b/packages/libsql-core/src/uri.ts
@@ -87,10 +87,7 @@ function parseAuthority(text: string): Authority {
 }
 
 const AUTHORITY_RE = (() => {
-    const USERINFO = '(?<username>[^:]*)(:(?<password>.*))?';
-    const HOST = '((?<host>[^:\\[\\]]*)|(\\[(?<host_br>[^\\[\\]]*)\\]))';
-    const PORT = '(?<port>[0-9]*)';
-    return new RegExp(`^(${USERINFO}@)?${HOST}(:${PORT})?$`, "su");
+  return new RegExp(`^((?<username>[^:]*)(:(?<password>.*))?@)?((?<host>[^:\\[\\]]*)|(\\[(?<host_br>[^\\[\\]]*)\\]))(:(?<port>[0-9]*))?$`, "su");
 })();
 
 // Query string is parsed as application/x-www-form-urlencoded according to the Web URL standard:


### PR DESCRIPTION
As mentioned in [this thread](https://github.com/vercel/next.js/issues/59540#issuecomment-1865008010), Next.js has errors that happen only when you run the build command related with regex. At least this was happening with bun + @libsql/client on the edge runtime.

The solution is to inline the variables that we use inside the regex constructor parameter, so Next.js doesn't have a change to try to optimize it.