### PR TITLE
Encryption key support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -936,9 +936,9 @@
       "link": true
     },
     "node_modules/@libsql/darwin-arm64": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@libsql/darwin-arm64/-/darwin-arm64-0.2.0.tgz",
-      "integrity": "sha512-+qyT2W/n5CFH1YZWv2mxW4Fsoo4dX9Z9M/nvbQqZ7H84J8hVegvVAsIGYzcK8xAeMEcpU5yGKB1Y9NoDY4hOSQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@libsql/darwin-arm64/-/darwin-arm64-0.3.1.tgz",
+      "integrity": "sha512-Yf8jFf6DHHTj7jtfjTTZPirYjwwqzMEUYmUlQvbEtlcRYNpj6N000atEfbvSRBOMx7stOqPQlymQZ2020xSKjw==",
       "cpu": [
         "arm64"
       ],
@@ -948,9 +948,9 @@
       ]
     },
     "node_modules/@libsql/darwin-x64": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@libsql/darwin-x64/-/darwin-x64-0.2.0.tgz",
-      "integrity": "sha512-hwmO2mF1n8oDHKFrUju6Jv+n9iFtTf5JUK+xlnIE3Td0ZwGC/O1R/Z/btZTd9nD+vsvakC8SJT7/Q6YlWIkhEw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@libsql/darwin-x64/-/darwin-x64-0.3.1.tgz",
+      "integrity": "sha512-4dciW+z1SBIfl6Oxec1t1cofaBYTP/xFcIZMJwfdaYuukwJFhKTIBjxS2ex048RGL86SpBPRR//ZDBi95kEYlA==",
       "cpu": [
         "x64"
       ],
@@ -1015,9 +1015,9 @@
       }
     },
     "node_modules/@libsql/linux-arm64-gnu": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-gnu/-/linux-arm64-gnu-0.2.0.tgz",
-      "integrity": "sha512-1w2lPXIYtnBaK5t/Ej5E8x7lPiE+jP3KATI/W4yei5Z/ONJh7jQW5PJ7sYU95vTME3hWEM1FXN6kvzcpFAte7w==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-gnu/-/linux-arm64-gnu-0.3.1.tgz",
+      "integrity": "sha512-7Ap1iZKSdPDWp47FnPgHDYhrwQ3lGFXRYEqMhD4YqI1BO5ywBcV564DkWVH4xIGA5fNsVDo0zaerVztWDNdJyQ==",
       "cpu": [
         "arm64"
       ],
@@ -1027,9 +1027,9 @@
       ]
     },
     "node_modules/@libsql/linux-arm64-musl": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-musl/-/linux-arm64-musl-0.2.0.tgz",
-      "integrity": "sha512-lkblBEJ7xuNiWNjP8DDq0rqoWccszfkUS7Efh5EjJ+GDWdCBVfh08mPofIZg0fZVLWQCY3j+VZCG1qZfATBizg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-musl/-/linux-arm64-musl-0.3.1.tgz",
+      "integrity": "sha512-bUAYqeyyr34J9SlBDdletpuUDp5jQrZ4B3Maqr9Hyut0nhN+raCa5Hno73W85GaFYmXgE5rCbMHDtcs0OLGMdQ==",
       "cpu": [
         "arm64"
       ],
@@ -1039,9 +1039,9 @@
       ]
     },
     "node_modules/@libsql/linux-x64-gnu": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@libsql/linux-x64-gnu/-/linux-x64-gnu-0.2.0.tgz",
-      "integrity": "sha512-+x/d289KeJydwOhhqSxKT+6MSQTCfLltzOpTzPccsvdt5fxg8CBi+gfvEJ4/XW23Sa+9bc7zodFP0i6MOlxX7w==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-x64-gnu/-/linux-x64-gnu-0.3.1.tgz",
+      "integrity": "sha512-7A3BtwLdJHjXB8kFuAtLmND66da8RwVeIfY1rRivDEyintv/HvXFmj+coIfniuO1xKvJtfaoJ8j2Fa5lObOnDg==",
       "cpu": [
         "x64"
       ],
@@ -1051,9 +1051,9 @@
       ]
     },
     "node_modules/@libsql/linux-x64-musl": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@libsql/linux-x64-musl/-/linux-x64-musl-0.2.0.tgz",
-      "integrity": "sha512-5Xn0c5A6vKf9D1ASpgk7mef//FuY7t5Lktj/eiU4n3ryxG+6WTpqstTittJUgepVjcleLPYxIhQAYeYwTYH1IQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-x64-musl/-/linux-x64-musl-0.3.1.tgz",
+      "integrity": "sha512-CyIhvt+t19yvT/y6wFkkFN2KA7ixmInWuHv1EP7hYXuGC7hXs1oAW8+5Sp2MGQdyVQRcenWyYp176nwjNBi12A==",
       "cpu": [
         "x64"
       ],
@@ -1063,9 +1063,9 @@
       ]
     },
     "node_modules/@libsql/win32-x64-msvc": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@libsql/win32-x64-msvc/-/win32-x64-msvc-0.2.0.tgz",
-      "integrity": "sha512-rpK+trBIpRST15m3cMYg5aPaX7kvCIottxY7jZPINkKAaScvfbn9yulU/iZUM9YtuK96Y1ZmvwyVIK/Y5DzoMQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@libsql/win32-x64-msvc/-/win32-x64-msvc-0.3.1.tgz",
+      "integrity": "sha512-o3pqBYP0GbnpkKOSNiRYPa5Z+L3mG5C1vIxcPEAkiXExSXfyYpKoridffyZsw47MhU4ZHLdoXFB35VLIIRmyhg==",
       "cpu": [
         "x64"
       ],
@@ -1076,8 +1076,8 @@
     },
     "node_modules/@neon-rs/load": {
       "version": "0.0.4",
-      "license": "MIT",
-      "optional": true
+      "resolved": "https://registry.npmjs.org/@neon-rs/load/-/load-0.0.4.tgz",
+      "integrity": "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw=="
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -1691,8 +1691,8 @@
     },
     "node_modules/detect-libc": {
       "version": "2.0.2",
-      "license": "Apache-2.0",
-      "optional": true,
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
+      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
       "engines": {
         "node": ">=8"
       }
@@ -2820,14 +2820,13 @@
       }
     },
     "node_modules/libsql": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/libsql/-/libsql-0.2.0.tgz",
-      "integrity": "sha512-ELBRqhpJx5Dap0187zKQnntZyk4EjlDHSrjIVL8t+fQ5e8IxbQTeYgZgigMjB1EvrETdkm0Y0VxBGhzPQ+t0Jg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/libsql/-/libsql-0.3.1.tgz",
+      "integrity": "sha512-L8CfxSSAtdTW9xGLWbhSr7gVYH8YHrsEumvcsbehPY9G11QmRPPo6y+vBD8IkIB8Jr/07xEiLa6ytx76sCtWZQ==",
       "cpu": [
         "x64",
         "arm64"
       ],
-      "optional": true,
       "os": [
         "darwin",
         "linux",
@@ -2838,13 +2837,13 @@
         "detect-libc": "2.0.2"
       },
       "optionalDependencies": {
-        "@libsql/darwin-arm64": "0.2.0",
-        "@libsql/darwin-x64": "0.2.0",
-        "@libsql/linux-arm64-gnu": "0.2.0",
-        "@libsql/linux-arm64-musl": "0.2.0",
-        "@libsql/linux-x64-gnu": "0.2.0",
-        "@libsql/linux-x64-musl": "0.2.0",
-        "@libsql/win32-x64-msvc": "0.2.0"
+        "@libsql/darwin-arm64": "0.3.1",
+        "@libsql/darwin-x64": "0.3.1",
+        "@libsql/linux-arm64-gnu": "0.3.1",
+        "@libsql/linux-arm64-musl": "0.3.1",
+        "@libsql/linux-x64-gnu": "0.3.1",
+        "@libsql/linux-x64-musl": "0.3.1",
+        "@libsql/win32-x64-msvc": "0.3.1"
       }
     },
     "node_modules/lines-and-columns": {
@@ -3901,7 +3900,8 @@
       "dependencies": {
         "@libsql/core": "^0.4.3",
         "@libsql/hrana-client": "^0.5.6",
-        "js-base64": "^3.7.5"
+        "js-base64": "^3.7.5",
+        "libsql": "^0.3.1"
       },
       "devDependencies": {
         "@types/jest": "^29.2.5",
@@ -3910,9 +3910,6 @@
         "ts-jest": "^29.0.5",
         "typedoc": "^0.23.28",
         "typescript": "^4.9.4"
-      },
-      "optionalDependencies": {
-        "libsql": "^0.2.0"
       }
     },
     "packages/libsql-client-wasm": {

--- a/packages/libsql-client/examples/example.js
+++ b/packages/libsql-client/examples/example.js
@@ -3,6 +3,7 @@ import { createClient } from "@libsql/client";
 async function example() {
   const config = {
     url: process.env.URL ?? "file:local.db",
+    encryptionKey: process.env.ENCRYPTION_KEY,
   };
   const db = createClient(config);
   await db.batch([

--- a/packages/libsql-client/package.json
+++ b/packages/libsql-client/package.json
@@ -101,10 +101,8 @@
     "dependencies": {
         "@libsql/core": "^0.4.3",
         "@libsql/hrana-client": "^0.5.6",
-        "js-base64": "^3.7.5"
-    },
-    "optionalDependencies": {
-        "libsql": "^0.2.0"
+        "js-base64": "^3.7.5",
+        "libsql": "^0.3.1"
     },
     "devDependencies": {
         "@types/jest": "^29.2.5",

--- a/packages/libsql-client/src/sqlite3.ts
+++ b/packages/libsql-client/src/sqlite3.ts
@@ -50,6 +50,7 @@ export function _createClient(config: ExpandedConfig): Client {
     const path = config.path;
     const options = {
         authToken: config.authToken,
+        encryptionKey: config.encryptionKey,
         syncUrl: config.syncUrl,
     };
 

--- a/packages/libsql-core/src/api.ts
+++ b/packages/libsql-core/src/api.ts
@@ -12,6 +12,9 @@ export interface Config {
     /** Authentication token for the database. */
     authToken?: string;
 
+    /** Encryption key for the database. */
+    encryptionKey?: string;
+
     /** URL of a remote server to synchronize database with. */
     syncUrl?: string;
 

--- a/packages/libsql-core/src/config.ts
+++ b/packages/libsql-core/src/config.ts
@@ -10,6 +10,7 @@ export interface ExpandedConfig {
     authority: Authority | undefined;
     path: string;
     authToken: string | undefined;
+    encryptionKey: string | undefined;
     syncUrl: string | undefined;
     intMode: IntMode;
     fetch: Function | undefined;
@@ -26,6 +27,7 @@ export function expandConfig(config: Config, preferHttp: boolean): ExpandedConfi
 
     let tls: boolean | undefined = config.tls;
     let authToken = config.authToken;
+    let encryptionKey = config.encryptionKey;
     let syncUrl = config.syncUrl;
     const intMode = ""+(config.intMode ?? "number");
     if (intMode !== "number" && intMode !== "bigint" && intMode !== "string") {
@@ -45,6 +47,7 @@ export function expandConfig(config: Config, preferHttp: boolean): ExpandedConfi
         fetch: config.fetch,
         tls: false,
         authToken: undefined,
+        encryptionKey: undefined,
         authority: undefined,
       };
     }
@@ -114,6 +117,7 @@ export function expandConfig(config: Config, preferHttp: boolean): ExpandedConfi
         authority: uri.authority,
         path: uri.path,
         authToken,
+        encryptionKey,
         syncUrl,
         intMode,
         fetch: config.fetch,


### PR DESCRIPTION
This pull request adds a new `encryptionKey` option to client, which allows users to define an encryption key to enable encryption at rest for local databases. In the future, we will expand this to encryption at rest over remote protocol too.

Depends on: https://github.com/tursodatabase/libsql-js/pull/77