### PR TITLE
Fail createClient() if encryption key not supported but specified

### DIFF
--- a/packages/libsql-client-wasm/src/wasm.ts
+++ b/packages/libsql-client-wasm/src/wasm.ts
@@ -29,6 +29,10 @@ export function _createClient(config: ExpandedConfig): Client {
         );
     }
 
+    if (config.encryptionKey !== undefined) {
+        throw new LibsqlError("Encryption key is not supported by the Wasm client.", "ENCRYPTION_KEY_NOT_SUPPORTED");
+    }
+
     const authority = config.authority;
     if (authority !== undefined) {
         const host = authority.host.toLowerCase();

--- a/packages/libsql-client/src/http.ts
+++ b/packages/libsql-client/src/http.ts
@@ -29,6 +29,10 @@ export function _createClient(config: ExpandedConfig): Client {
         );
     }
 
+    if (config.encryptionKey !== undefined) {
+        throw new LibsqlError("Encryption key is not supported by the remote client.", "ENCRYPTION_KEY_NOT_SUPPORTED");
+    }
+
     if (config.scheme === "http" && config.tls) {
         throw new LibsqlError(`A "http:" URL cannot opt into TLS by using ?tls=1`, "URL_INVALID");
     } else if (config.scheme === "https" && !config.tls) {

--- a/packages/libsql-client/src/ws.ts
+++ b/packages/libsql-client/src/ws.ts
@@ -28,6 +28,10 @@ export function _createClient(config: ExpandedConfig): WsClient {
         );
     }
 
+    if (config.encryptionKey !== undefined) {
+        throw new LibsqlError("Encryption key is not supported by the remote client.", "ENCRYPTION_KEY_NOT_SUPPORTED");
+    }
+
     if (config.scheme === "ws" && config.tls) {
         throw new LibsqlError(`A "ws:" URL cannot opt into TLS by using ?tls=1`, "URL_INVALID");
     } else if (config.scheme === "wss" && !config.tls) {


### PR DESCRIPTION
The encryptionKey option only works with local databases for now.