### PR TITLE
fix: only cache statement under 5kb

### DIFF
--- a/packages/libsql-client/src/sql_cache.ts
+++ b/packages/libsql-client/src/sql_cache.ts
@@ -31,6 +31,12 @@ export class SqlCache {
             }
             const sqlText = hranaStmt.sql;
 
+            // Stored SQL cannot exceed 5kb.
+            // https://github.com/tursodatabase/libsql/blob/e9d637e051685f92b0da43849507b5ef4232fbeb/libsql-server/src/hrana/http/request.rs#L10
+            if (sqlText.length >= 5000) {
+                continue;
+            }
+
             let sqlObj = this.#sqls.get(sqlText);
             if (sqlObj === undefined) {
                 while (this.#sqls.size + 1 > this.capacity) {


### PR DESCRIPTION
Batch is using stored_sql. In the Turso server, the stored_sql only support up to 5kb only.

https://github.com/tursodatabase/libsql/blob/e9d637e051685f92b0da43849507b5ef4232fbeb/libsql-server/src/hrana/http/request.rs#L10

- Checking 5,000 characters doesnt seem like good idea given that unicode character might takes multiple bytes. One solution is to check 1,000 characters instead. Unicode at most takes 4 bytes. 5,000 / 4= 1250 characters.
- Or we can just remove the SQL cache in the batch

Related to this issue:
https://github.com/tursodatabase/libsql-client-ts/issues/177#issuecomment-2040989370