### PR TITLE
Don't raise an error if server doesn't implement the migrations endpoint

### DIFF
--- a/packages/libsql-client/src/migrations.ts
+++ b/packages/libsql-client/src/migrations.ts
@@ -81,7 +81,11 @@ export async function getIsSchemaDatabase({
     authToken: string | undefined;
     baseUrl: string;
 }) {
+    if (baseUrl.startsWith("http://127.0.0.1")) {
+        return false;
+    }
     const url = normalizeURLScheme(baseUrl + "/v1/jobs");
+
     const result = await fetch(url, {
         method: "GET",
         headers: {

--- a/packages/libsql-client/src/migrations.ts
+++ b/packages/libsql-client/src/migrations.ts
@@ -104,7 +104,6 @@ export async function getIsSchemaDatabase({
             result.status === 400 && json.error === "Invalid namespace";
         return !isChildDatabase;
     } catch (e) {
-        console.error(e);
         console.error(
             [
                 `There has been an error while retrieving the database type.`,

--- a/packages/libsql-client/src/migrations.ts
+++ b/packages/libsql-client/src/migrations.ts
@@ -94,7 +94,7 @@ export async function getIsSchemaDatabase({
                 Authorization: `Bearer ${authToken}`,
             },
         });
-        if (result.status === 404) {
+        if (result.status === 404 || result.status === 500) {
             return false;
         }
 

--- a/packages/libsql-client/src/migrations.ts
+++ b/packages/libsql-client/src/migrations.ts
@@ -88,7 +88,12 @@ export async function getIsSchemaDatabase({
             Authorization: `Bearer ${authToken}`,
         },
     });
+    if (result.status === 404) {
+        return false;
+    }
+
     const json = (await result.json()) as { error: string };
+
     const isChildDatabase =
         result.status === 400 && json.error === "Invalid namespace";
     return !isChildDatabase;


### PR DESCRIPTION
There are some cases where the `/v1/jobs` endpoint doesn't exist so this API call returns a 404 and makes the client to fail.
This PR handles this case without raising an error.