### PR TITLE
support query parameters recognized by sqlite3 in uri for :memory: connection

### DIFF
--- a/packages/libsql-client/src/__tests__/client.test.ts
+++ b/packages/libsql-client/src/__tests__/client.test.ts
@@ -291,6 +291,17 @@ describe("execute()", () => {
             expect(Array.from(selectRs.rows[0])).toStrictEqual(["three"]);
         }),
     );
+
+    // see issue https://github.com/tursodatabase/libsql/issues/1411
+    test(
+        "execute transaction with in memory database",
+        withInMemoryClient(async (c) => {
+            await c.execute("CREATE TABLE t (a)");
+            const transaction = await c.transaction();
+            transaction.close();
+            await c.execute("SELECT * FROM t");
+        }),
+    );
 });
 
 describe("values", () => {

--- a/packages/libsql-client/src/__tests__/client.test.ts
+++ b/packages/libsql-client/src/__tests__/client.test.ts
@@ -294,13 +294,44 @@ describe("execute()", () => {
 
     // see issue https://github.com/tursodatabase/libsql/issues/1411
     test(
-        "execute transaction with in memory database",
-        withInMemoryClient(async (c) => {
-            await c.execute("CREATE TABLE t (a)");
-            const transaction = await c.transaction();
-            transaction.close();
-            await c.execute("SELECT * FROM t");
-        }),
+        "execute transaction against in memory database with shared cache",
+        withClient(
+            async (c) => {
+                await c.execute("CREATE TABLE t (a)");
+                const transaction = await c.transaction();
+                transaction.close();
+                await c.execute("SELECT * FROM t");
+            },
+            { url: "file::memory:?cache=shared" },
+        ),
+    );
+    test(
+        "execute transaction against in memory database with private cache",
+        withClient(
+            async (c) => {
+                await c.execute("CREATE TABLE t (a)");
+                const transaction = await c.transaction();
+                transaction.close();
+                expect(() => c.execute("SELECT * FROM t")).rejects.toThrow(
+                    LibsqlError,
+                );
+            },
+            { url: "file::memory:?cache=private" },
+        ),
+    );
+    test(
+        "execute transaction against in memory database with default cache",
+        withClient(
+            async (c) => {
+                await c.execute("CREATE TABLE t (a)");
+                const transaction = await c.transaction();
+                transaction.close();
+                expect(() => c.execute("SELECT * FROM t")).rejects.toThrow(
+                    LibsqlError,
+                );
+            },
+            { url: ":memory:" },
+        ),
     );
 });
 

--- a/packages/libsql-client/src/__tests__/client.test.ts
+++ b/packages/libsql-client/src/__tests__/client.test.ts
@@ -312,9 +312,7 @@ describe("execute()", () => {
                 await c.execute("CREATE TABLE t (a)");
                 const transaction = await c.transaction();
                 transaction.close();
-                expect(() => c.execute("SELECT * FROM t")).rejects.toThrow(
-                    LibsqlError,
-                );
+                expect(() => c.execute("SELECT * FROM t")).rejects.toThrow();
             },
             { url: "file::memory:?cache=private" },
         ),
@@ -326,9 +324,7 @@ describe("execute()", () => {
                 await c.execute("CREATE TABLE t (a)");
                 const transaction = await c.transaction();
                 transaction.close();
-                expect(() => c.execute("SELECT * FROM t")).rejects.toThrow(
-                    LibsqlError,
-                );
+                expect(() => c.execute("SELECT * FROM t")).rejects.toThrow();
             },
             { url: ":memory:" },
         ),

--- a/packages/libsql-client/src/__tests__/config.test.ts
+++ b/packages/libsql-client/src/__tests__/config.test.ts
@@ -1,0 +1,147 @@
+import { expect } from "@jest/globals";
+
+import "./helpers.js";
+
+import { expandConfig } from "@libsql/core/config";
+
+describe("expandConfig - default tls values", () => {
+    const cases = [
+        {
+            name: "file",
+            preferHttp: true,
+            config: { url: "file://local.db" },
+            tls: true,
+        },
+        {
+            name: "http",
+            preferHttp: true,
+            config: { url: "http://localhost" },
+            tls: false,
+        },
+        {
+            name: "http (tls in config)",
+            preferHttp: true,
+            config: { url: "http://localhost", tls: true },
+            tls: true,
+        },
+        {
+            name: "http (tls in query)",
+            preferHttp: true,
+            config: { url: "http://localhost?tls=1", tls: false },
+            tls: true,
+        },
+        {
+            name: "http (no tls in query)",
+            preferHttp: true,
+            config: { url: "http://localhost?tls=0", tls: true },
+            tls: false,
+        },
+        {
+            name: "http (no tls in query)",
+            preferHttp: true,
+            config: { url: "http://localhost?tls=0", tls: true },
+            tls: false,
+        },
+    ];
+    for (const { name, config, preferHttp, tls } of cases) {
+        test(name, () => {
+            expect(expandConfig(config, preferHttp).tls).toEqual(tls);
+        });
+    }
+});
+
+describe("expandConfig - parsing of valid arguments", () => {
+    const cases = [
+        {
+            name: "in-memory",
+            config: { url: ":memory:" },
+            expanded: {
+                scheme: "file",
+                tls: false,
+                intMode: "number",
+                path: ":memory:",
+            },
+        },
+        {
+            name: "simple local file",
+            config: { url: "file://local.db" },
+            expanded: {
+                scheme: "file",
+                authority: { host: "local.db" },
+                tls: true,
+                intMode: "number",
+                path: "",
+            },
+        },
+        {
+            name: "wss with path & port",
+            config: { url: "wss://localhost:8888/libsql/connect" },
+            expanded: {
+                scheme: "wss",
+                authority: { host: "localhost", port: 8888 },
+                tls: true,
+                intMode: "number",
+                path: "/libsql/connect",
+            },
+        },
+        {
+            name: "wss with user info",
+            config: {
+                url: "wss://user:password@localhost:8888/libsql/connect",
+            },
+            expanded: {
+                scheme: "wss",
+                authority: {
+                    host: "localhost",
+                    port: 8888,
+                    userinfo: { username: "user", password: "password" },
+                },
+                tls: true,
+                intMode: "number",
+                path: "/libsql/connect",
+            },
+        },
+        {
+            name: "override tls=0",
+            config: { url: "wss://localhost/libsql/connect?tls=0", tls: true },
+            expanded: {
+                scheme: "wss",
+                authority: { host: "localhost" },
+                tls: false,
+                intMode: "number",
+                path: "/libsql/connect",
+            },
+        },
+        {
+            name: "override tls=1",
+            config: { url: "wss://localhost/libsql/connect?tls=1", tls: false },
+            expanded: {
+                scheme: "wss",
+                authority: { host: "localhost" },
+                tls: true,
+                intMode: "number",
+                path: "/libsql/connect",
+            },
+        },
+        {
+            name: "override auth token",
+            config: {
+                url: "wss://localhost/libsql/connect?authToken=new",
+                authToken: "old",
+            },
+            expanded: {
+                authToken: "new",
+                scheme: "wss",
+                authority: { host: "localhost" },
+                tls: true,
+                intMode: "number",
+                path: "/libsql/connect",
+            },
+        },
+    ];
+    for (const { name, config, expanded } of cases) {
+        test(name, () => {
+            expect(expandConfig(config, false)).toEqual(expanded);
+        });
+    }
+});

--- a/packages/libsql-client/src/__tests__/config.test.ts
+++ b/packages/libsql-client/src/__tests__/config.test.ts
@@ -116,6 +116,7 @@ describe("expandConfig - parsing of valid arguments", () => {
                 tls: false,
                 intMode: "number",
                 path: ":memory:",
+                concurrency: 20,
             },
         },
         {
@@ -126,6 +127,7 @@ describe("expandConfig - parsing of valid arguments", () => {
                 tls: false,
                 intMode: "number",
                 path: ":memory:?cache=shared",
+                concurrency: 20,
             },
         },
         {
@@ -137,6 +139,7 @@ describe("expandConfig - parsing of valid arguments", () => {
                 tls: true,
                 intMode: "number",
                 path: "",
+                concurrency: 20,
             },
         },
         {
@@ -148,12 +151,14 @@ describe("expandConfig - parsing of valid arguments", () => {
                 tls: true,
                 intMode: "number",
                 path: "/libsql/connect",
+                concurrency: 20,
             },
         },
         {
             name: "wss with user info",
             config: {
                 url: "wss://user:password@localhost:8888/libsql/connect",
+                concurrency: 20,
             },
             expanded: {
                 scheme: "wss",
@@ -165,6 +170,7 @@ describe("expandConfig - parsing of valid arguments", () => {
                 tls: true,
                 intMode: "number",
                 path: "/libsql/connect",
+                concurrency: 20,
             },
         },
         {
@@ -176,6 +182,7 @@ describe("expandConfig - parsing of valid arguments", () => {
                 tls: false,
                 intMode: "number",
                 path: "/libsql/connect",
+                concurrency: 20,
             },
         },
         {
@@ -187,6 +194,7 @@ describe("expandConfig - parsing of valid arguments", () => {
                 tls: true,
                 intMode: "number",
                 path: "/libsql/connect",
+                concurrency: 20,
             },
         },
         {
@@ -202,6 +210,7 @@ describe("expandConfig - parsing of valid arguments", () => {
                 tls: true,
                 intMode: "number",
                 path: "/libsql/connect",
+                concurrency: 20,
             },
         },
     ];

--- a/packages/libsql-client/src/__tests__/config.test.ts
+++ b/packages/libsql-client/src/__tests__/config.test.ts
@@ -3,6 +3,7 @@ import { expect } from "@jest/globals";
 import "./helpers.js";
 
 import { expandConfig } from "@libsql/core/config";
+import { IntMode } from "@libsql/hrana-client";
 
 describe("expandConfig - default tls values", () => {
     const cases = [
@@ -50,6 +51,61 @@ describe("expandConfig - default tls values", () => {
     }
 });
 
+describe("expandConfig - invalid arguments", () => {
+    const cases = [
+        {
+            name: "in-memory with unsupported query params",
+            config: { url: "file::memory:?mode=memory" },
+            error: 'Unsupported URL query parameter "mode"',
+        },
+        {
+            name: "in-memory with tls param",
+            config: { url: "file::memory:?tls=0" },
+            error: 'Unsupported URL query parameter "tls"',
+        },
+        {
+            name: "in-memory with authToken param",
+            config: { url: "file::memory:?authToken=0" },
+            error: 'Unsupported URL query parameter "authToken"',
+        },
+        {
+            name: "invalid tls param value",
+            config: { url: "libsql://localhost?tls=2" },
+            error: 'Unknown value for the "tls" query argument: "2". Supported values are: ["0", "1"]',
+        },
+        {
+            name: "invalid scheme",
+            config: { url: "ftp://localhost" },
+            error: /The client supports only.*got "ftp:"/g,
+        },
+        {
+            name: "invalid intMode",
+            config: { url: "file://localhost", intMode: "decimal" as IntMode },
+            error: /Invalid value for intMode.*got "decimal"/g,
+        },
+        {
+            name: "fragment in uri",
+            config: { url: "file://localhost#fragment" },
+            error: "URL fragments are not supported",
+        },
+        {
+            name: "libsql, no tls, no port",
+            config: { url: "libsql://localhost?tls=0" },
+            error: "must specify an explicit port",
+        },
+    ];
+    for (const { name, config, error } of cases) {
+        test(name, () => {
+            try {
+                expandConfig(config, false);
+                throw new Error("expand command must fail");
+            } catch (e: any) {
+                expect(e.message).toMatch(error);
+            }
+        });
+    }
+});
+
 describe("expandConfig - parsing of valid arguments", () => {
     const cases = [
         {
@@ -60,6 +116,16 @@ describe("expandConfig - parsing of valid arguments", () => {
                 tls: false,
                 intMode: "number",
                 path: ":memory:",
+            },
+        },
+        {
+            name: "in-memory with params",
+            config: { url: "file::memory:?cache=shared" },
+            expanded: {
+                scheme: "file",
+                tls: false,
+                intMode: "number",
+                path: ":memory:?cache=shared",
             },
         },
         {

--- a/packages/libsql-client/src/__tests__/uri.test.ts
+++ b/packages/libsql-client/src/__tests__/uri.test.ts
@@ -1,11 +1,23 @@
 import { expect } from "@jest/globals";
-import type { MatcherFunction } from "expect";
 
 import "./helpers.js";
 
 import { parseUri, encodeBaseUrl } from "@libsql/core/uri";
 
 describe("parseUri()", () => {
+    test(":memory: uri", () => {
+        const cases = [
+            { text: "file::memory:", path: ":memory:", query: undefined },
+            {
+                text: "file::memory:?cache=shared",
+                path: ":memory:",
+                query: { pairs: [{ key: "cache", value: "shared" }] },
+            },
+        ];
+        for (const { text, path, query } of cases) {
+            expect(parseUri(text)).toEqual({ scheme: "file", path, query });
+        }
+    });
     test("authority and path", () => {
         const cases = [
             { text: "file://localhost", path: "" },

--- a/packages/libsql-client/src/sqlite3.ts
+++ b/packages/libsql-client/src/sqlite3.ts
@@ -62,7 +62,8 @@ export function _createClient(config: ExpandedConfig): Client {
         }
     }
 
-    const path = config.path;
+    // note: we must always prepend file scheme in order for SQLite3 to recognize :memory: connection query parameters
+    const path = `${config.scheme}:${config.path}`;
     const options = {
         authToken: config.authToken,
         encryptionKey: config.encryptionKey,

--- a/packages/libsql-core/src/config.ts
+++ b/packages/libsql-core/src/config.ts
@@ -155,8 +155,6 @@ export function expandConfig(
         );
     }
 
-    // todo: libsql-client-ts may want to validate parameters for the "in-memory" mode and throw if some of them filled unexpectedly
-    // but, in order to not break compatibility between clients for now client doesn't do these validations and just ignore parameters
     if (isInMemoryMode) {
         return {
             scheme: "file",

--- a/packages/libsql-core/src/config.ts
+++ b/packages/libsql-core/src/config.ts
@@ -174,7 +174,7 @@ export function expandConfig(
 
     return {
         scheme,
-        tls: tls,
+        tls,
         authority: uri.authority,
         path,
         authToken,


### PR DESCRIPTION
## Context

This PR can address issue https://github.com/tursodatabase/libsql/issues/1411

Transactions within in-memory database are "useless" because client always reset DB connection and recreate it after transaction from scratch which leads to blank state of the in-memory DB after each transaction.

This can be fixed with native SQLite support of connection parameters propagated through query param string: see https://sqlite.org/uri.html#recognized_query_parameters

So, problem can be resolved for such scenarios if `file::memory:?cache=shared` will be provided as connection URI.

## Changes

- This PR add support for `cache` query parameter for in-memory mode in the config enrichment & validation procedure.
    * The addition is rather conservative and for now only allows to set `cache=shared|private` value for the in-memory mode **only**

## Testing

- Run unit tests locally
- Run "node-tests" workflow with [act](https://github.com/nektos/act)