### PR TITLE
Improve invalid URL error message

### DIFF
--- a/packages/libsql-core/src/uri.ts
+++ b/packages/libsql-core/src/uri.ts
@@ -42,7 +42,7 @@ export function parseUri(text: string): Uri {
     const match = URI_RE.exec(text);
     if (match === null) {
         throw new LibsqlError(
-            "The URL is not in a valid format",
+            `The URL '${text}' is not in a valid format`,
             "URL_INVALID",
         );
     }


### PR DESCRIPTION
People are hitting invalid URL errors as discussed in tursodatabase/libsql#1121. Let's improve the error message to actually include the URL that the driver sees to make debugging easier.