### PR TITLE
Add concurrency limits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3996,6 +3996,11 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/promise-limit": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/promise-limit/-/promise-limit-2.7.0.tgz",
+            "integrity": "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw=="
+        },
         "node_modules/prompts": {
             "version": "2.4.2",
             "dev": true,
@@ -4713,7 +4718,7 @@
                 "@libsql/hrana-client": "^0.6.0",
                 "js-base64": "^3.7.5",
                 "libsql": "^0.3.10",
-                "p-limit": "^5.0.0"
+                "promise-limit": "^2.7.0"
             },
             "devDependencies": {
                 "@types/jest": "^29.2.5",
@@ -4746,31 +4751,6 @@
                 "ts-jest": "^29.0.5",
                 "typedoc": "^0.23.28",
                 "typescript": "^4.9.4"
-            }
-        },
-        "packages/libsql-client/node_modules/p-limit": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
-            "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
-            "dependencies": {
-                "yocto-queue": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "packages/libsql-client/node_modules/yocto-queue": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
-            "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
-            "engines": {
-                "node": ">=12.20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "packages/libsql-core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4712,7 +4712,8 @@
                 "@libsql/core": "^0.6.2",
                 "@libsql/hrana-client": "^0.6.0",
                 "js-base64": "^3.7.5",
-                "libsql": "^0.3.10"
+                "libsql": "^0.3.10",
+                "p-limit": "^5.0.0"
             },
             "devDependencies": {
                 "@types/jest": "^29.2.5",
@@ -4745,6 +4746,31 @@
                 "ts-jest": "^29.0.5",
                 "typedoc": "^0.23.28",
                 "typescript": "^4.9.4"
+            }
+        },
+        "packages/libsql-client/node_modules/p-limit": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+            "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+            "dependencies": {
+                "yocto-queue": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/libsql-client/node_modules/yocto-queue": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+            "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+            "engines": {
+                "node": ">=12.20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "packages/libsql-core": {

--- a/packages/libsql-client/package.json
+++ b/packages/libsql-client/package.json
@@ -105,7 +105,8 @@
         "@libsql/core": "^0.6.2",
         "@libsql/hrana-client": "^0.6.0",
         "js-base64": "^3.7.5",
-        "libsql": "^0.3.10"
+        "libsql": "^0.3.10",
+        "p-limit": "^5.0.0"
     },
     "devDependencies": {
         "@types/jest": "^29.2.5",

--- a/packages/libsql-client/package.json
+++ b/packages/libsql-client/package.json
@@ -106,7 +106,7 @@
         "@libsql/hrana-client": "^0.6.0",
         "js-base64": "^3.7.5",
         "libsql": "^0.3.10",
-        "p-limit": "^5.0.0"
+        "promise-limit": "^2.7.0"
     },
     "devDependencies": {
         "@types/jest": "^29.2.5",

--- a/packages/libsql-client/src/http.ts
+++ b/packages/libsql-client/src/http.ts
@@ -24,11 +24,11 @@ import {
     getIsSchemaDatabase,
     waitForLastMigrationJobToFinish,
 } from "./migrations.js";
-import pLimit from "p-limit";
+import promiseLimit from "promise-limit";
 
 export * from "@libsql/core/api";
 
-const limit = pLimit(1);
+const limit = promiseLimit<ResultSet>(1);
 
 export function createClient(config: Config): Client {
     return _createClient(expandConfig(config, true));

--- a/packages/libsql-client/src/http.ts
+++ b/packages/libsql-client/src/http.ts
@@ -87,7 +87,7 @@ export class HttpClient implements Client {
         authToken: string | undefined,
         intMode: IntMode,
         customFetch: Function | undefined,
-        concurrency: number | undefined,
+        concurrency: number,
     ) {
         this.#client = hrana.openHttp(url, authToken, customFetch);
         this.#client.intMode = intMode;

--- a/packages/libsql-client/src/http.ts
+++ b/packages/libsql-client/src/http.ts
@@ -213,7 +213,7 @@ export class HttpClient implements Client {
     }
 
     async executeMultiple(sql: string): Promise<void> {
-        this.limit<void>(async () => {
+        return this.limit<void>(async () => {
             try {
                 // Pipeline all operations, so `hrana.HttpClient` can open the stream, execute the sequence and
                 // close the stream in a single HTTP request.

--- a/packages/libsql-client/src/ws.ts
+++ b/packages/libsql-client/src/ws.ts
@@ -254,7 +254,7 @@ export class WsClient implements Client {
     }
 
     async executeMultiple(sql: string): Promise<void> {
-        this.limit<void>(async () => {
+        return this.limit<void>(async () => {
             const streamState = await this.#openStream();
             try {
                 // Schedule all operations synchronously, so they will be pipelined and executed in a single

--- a/packages/libsql-core/src/api.ts
+++ b/packages/libsql-core/src/api.ts
@@ -46,6 +46,14 @@ export interface Config {
      * with the Web `Response`.
      */
     fetch?: Function;
+
+    /** Concurrency limit.
+     *
+     * By default, the client performs up to 20 concurrent requests. You can set this option to a higher
+     * number to increase the concurrency limit. You can also set this option to `undefined` to disable concurrency
+     * completely.
+     */
+    concurrency?: number | undefined;
 }
 
 /** Representation of integers from database as JavaScript values. See {@link Config.intMode}. */

--- a/packages/libsql-core/src/config.ts
+++ b/packages/libsql-core/src/config.ts
@@ -15,7 +15,7 @@ export interface ExpandedConfig {
     syncInterval: number | undefined;
     intMode: IntMode;
     fetch: Function | undefined;
-    concurrency: number | undefined;
+    concurrency: number;
 }
 
 export type ExpandedScheme = "wss" | "ws" | "https" | "http" | "file";
@@ -32,7 +32,7 @@ export function expandConfig(
         );
     }
 
-    const concurrency = "concurrency" in config ? config.concurrency : 20;
+    const concurrency = Math.max(0, config.concurrency || 20);
     let tls: boolean | undefined = config.tls;
     let authToken = config.authToken;
     let encryptionKey = config.encryptionKey;

--- a/packages/libsql-core/src/config.ts
+++ b/packages/libsql-core/src/config.ts
@@ -15,6 +15,7 @@ export interface ExpandedConfig {
     syncInterval: number | undefined;
     intMode: IntMode;
     fetch: Function | undefined;
+    concurrency: number | undefined;
 }
 
 export type ExpandedScheme = "wss" | "ws" | "https" | "http" | "file";
@@ -31,6 +32,7 @@ export function expandConfig(
         );
     }
 
+    const concurrency = "concurrency" in config ? config.concurrency : 20;
     let tls: boolean | undefined = config.tls;
     let authToken = config.authToken;
     let encryptionKey = config.encryptionKey;
@@ -56,6 +58,7 @@ export function expandConfig(
             authToken: undefined,
             encryptionKey: undefined,
             authority: undefined,
+            concurrency,
         };
     }
 
@@ -133,5 +136,6 @@ export function expandConfig(
         syncInterval,
         intMode,
         fetch: config.fetch,
+        concurrency,
     };
 }


### PR DESCRIPTION
This PR to limits the number of parallel executions when calling the `execute`, `batch`, `transaction`, and `executeMultiple` methods. The number of parallel executions that can be executed is 20 by default, and can be customized by providing a new `concurrency` parameter when initializing the client as follows:

```js
export const turso = createClient({
  url: process.env.TURSO_DATABASE_URL,
  authToken: process.env.TURSO_AUTH_TOKEN,
  concurrency: 10 // defaults to 20 and undefined means there's no concurrency limit
});
```