### PR TITLE
Fix race condition on getIsSchemaDatabase cache

### DIFF
--- a/packages/libsql-client/src/http.ts
+++ b/packages/libsql-client/src/http.ts
@@ -71,7 +71,7 @@ export class HttpClient implements Client {
     protocol: "http";
     #url: URL;
     #authToken: string | undefined;
-    #isSchemaDatabase: boolean | undefined;
+    #isSchemaDatabase: Promise<boolean> | undefined;
 
     /** @private */
     constructor(
@@ -87,9 +87,9 @@ export class HttpClient implements Client {
         this.#authToken = authToken;
     }
 
-    async getIsSchemaDatabase(): Promise<boolean> {
+    getIsSchemaDatabase(): Promise<boolean> {
         if (this.#isSchemaDatabase === undefined) {
-            this.#isSchemaDatabase = await getIsSchemaDatabase({
+            this.#isSchemaDatabase = getIsSchemaDatabase({
                 authToken: this.#authToken,
                 baseUrl: this.#url.origin,
             });

--- a/packages/libsql-client/src/ws.ts
+++ b/packages/libsql-client/src/ws.ts
@@ -124,7 +124,7 @@ export class WsClient implements Client {
     #futureConnState: ConnState | undefined;
     closed: boolean;
     protocol: "ws";
-    #isSchemaDatabase: boolean | undefined;
+    #isSchemaDatabase: Promise<boolean> | undefined;
 
     /** @private */
     constructor(
@@ -142,9 +142,9 @@ export class WsClient implements Client {
         this.protocol = "ws";
     }
 
-    async getIsSchemaDatabase(): Promise<boolean> {
+    getIsSchemaDatabase(): Promise<boolean> {
         if (this.#isSchemaDatabase === undefined) {
-            this.#isSchemaDatabase = await getIsSchemaDatabase({
+            this.#isSchemaDatabase = getIsSchemaDatabase({
                 authToken: this.#authToken,
                 baseUrl: this.#url.origin,
             });


### PR DESCRIPTION
We a client instance is used concurrently before the isSchemaDatabasePromise is resolved, this led to multiple executions of the underlying function. It should only be executed once, and the promise should be shared among callers, which is what this change enables.