### PR TITLE
Update docs for the concurrency parameter

### DIFF
--- a/packages/libsql-core/src/api.ts
+++ b/packages/libsql-core/src/api.ts
@@ -50,7 +50,7 @@ export interface Config {
     /** Concurrency limit.
      *
      * By default, the client performs up to 20 concurrent requests. You can set this option to a higher
-     * number to increase the concurrency limit. You can also set this option to `0` to disable concurrency limits.
+     * number to increase the concurrency limit or set it to `0` to disable concurrency limits completely.
      */
     concurrency?: number | undefined;
 }

--- a/packages/libsql-core/src/api.ts
+++ b/packages/libsql-core/src/api.ts
@@ -50,7 +50,7 @@ export interface Config {
     /** Concurrency limit.
      *
      * By default, the client performs up to 20 concurrent requests. You can set this option to a higher
-     * number to increase the concurrency limit or set it to `0` to disable concurrency limits completely.
+     * number to increase the concurrency limit or set it to 0 to disable concurrency limits completely.
      */
     concurrency?: number | undefined;
 }

--- a/packages/libsql-core/src/api.ts
+++ b/packages/libsql-core/src/api.ts
@@ -50,8 +50,7 @@ export interface Config {
     /** Concurrency limit.
      *
      * By default, the client performs up to 20 concurrent requests. You can set this option to a higher
-     * number to increase the concurrency limit. You can also set this option to `undefined` to disable concurrency
-     * completely.
+     * number to increase the concurrency limit. You can also set this option to `0` to disable concurrency limits.
      */
     concurrency?: number | undefined;
 }


### PR DESCRIPTION
Current behavior is that when `concurrency` is set to `undefined` (or not providing a value at all), we set it to `20`. Also, when it's set to `0`, it means that we won't apply concurrency limits at all.

This PR updates the docs accordingly.