### PR TITLE
recreate DB connection in wasm mode correctly after init of a transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 -   Bump hrana client to 0.6.2.
 -   Support `cache=private|shared` [query parameter](https://www.sqlite.org/uri.html#recognized_query_parameters) in the connection string to local SQLite (https://github.com/tursodatabase/libsql-client-ts/pull/220)
+-   Fix bug in wasm experimental client which appears when transaction are used in local mode (https://github.com/tursodatabase/libsql-client-ts/pull/231)
 
 ## 0.7.0 -- 2024-06-25
 

--- a/packages/libsql-client-wasm/src/wasm.ts
+++ b/packages/libsql-client-wasm/src/wasm.ts
@@ -195,7 +195,7 @@ export class Sqlite3Client implements Client {
     // Lazily creates the database connection and returns it
     #getDb(): Database {
         if (this.#db === null) {
-            this.#db = new this.#sqlite3.oo1.DB("/mydb.sqlite3", "ct");
+            this.#db = new sqlite3.oo1.DB(this.#path, "c");
         }
         return this.#db;
     }


### PR DESCRIPTION
Some hard-coded values were used to lazily recreate connection. We must use `#path` provided in the ctor instead.