### PR TITLE
Don't raise errors if there are no pending migrations

### DIFF
--- a/packages/libsql-client/src/migrations.ts
+++ b/packages/libsql-client/src/migrations.ts
@@ -121,7 +121,7 @@ export async function getIsSchemaDatabase({
 async function getLastMigrationJob({
     authToken,
     baseUrl,
-}: getLastMigrationJobProps): Promise<MigrationJobType> {
+}: getLastMigrationJobProps): Promise<MigrationJobType | null> {
     const url = normalizeURLScheme(baseUrl + "/v1/jobs");
     const result = await fetch(url, {
         method: "GET",
@@ -138,7 +138,7 @@ async function getLastMigrationJob({
 
     const json = (await result.json()) as MigrationResult;
     if (!json.migrations || json.migrations.length === 0) {
-        throw new Error("No migrations found");
+        return null;
     }
 
     const migrations = json.migrations || [];
@@ -171,6 +171,9 @@ export async function waitForLastMigrationJobToFinish({
         authToken: authToken,
         baseUrl,
     });
+    if (!lastMigrationJob) {
+        return;
+    }
     if (lastMigrationJob.status !== "RunSuccess") {
         let i = 0;
         while (i < SCHEMA_MIGRATION_MAX_RETRIES) {


### PR DESCRIPTION
Currently, we are raising an error if there are no pending migrations for a schema databases.
I think that we shouldn't raise an error if there are no pending migrations. However, I may be missing something because the Go implementation [has the same behavior](https://github.com/tursodatabase/tursotest/blob/4980936210eef1e931e251f972db32128cb5aa72/internal/integrationtests/shared_schema.go#L56). Maybe @haaawk can give us more context here.

This is currently causing issues like the ones reported here:
- https://discord.com/channels/933071162680958986/1250540752396882011/1250540752396882011
- https://github.com/drizzle-team/drizzle-kit-mirror/issues/484