### PR TITLE
Execute overloading

### DIFF
--- a/packages/libsql-client-wasm/src/wasm.ts
+++ b/packages/libsql-client-wasm/src/wasm.ts
@@ -2,7 +2,6 @@ import sqlite3InitModule from "@libsql/libsql-wasm-experimental";
 
 import type {
     Database,
-    InitOptions,
     SqlValue,
     Sqlite3Static,
 } from "@libsql/libsql-wasm-experimental";
@@ -18,6 +17,7 @@ import type {
     Value,
     InValue,
     InStatement,
+    InArgs
 } from "@libsql/core/api";
 import { LibsqlError } from "@libsql/core/api";
 import type { ExpandedConfig } from "@libsql/core/config";
@@ -122,7 +122,21 @@ export class Sqlite3Client implements Client {
         this.protocol = "file";
     }
 
-    async execute(stmt: InStatement): Promise<ResultSet> {
+    async execute(stmt: InStatement): Promise<ResultSet>;
+    async execute(sql: string, args?: InArgs): Promise<ResultSet>;
+
+    async execute(stmtOrSql: InStatement | string, args?: InArgs): Promise<ResultSet> {
+      let stmt: InStatement;
+
+      if (typeof stmtOrSql === 'string') {
+        stmt = {
+            sql: stmtOrSql,
+            args: args || []
+        };
+      } else {
+          stmt = stmtOrSql;
+      }
+
         this.#checkNotClosed();
         return executeStmt(this.#getDb(), stmt, this.#intMode);
     }

--- a/packages/libsql-client/src/http.ts
+++ b/packages/libsql-client/src/http.ts
@@ -6,6 +6,7 @@ import type {
     ResultSet,
     Transaction,
     IntMode,
+    InArgs
 } from "@libsql/core/api";
 import { TransactionMode, LibsqlError } from "@libsql/core/api";
 import type { ExpandedConfig } from "@libsql/core/config";
@@ -112,7 +113,21 @@ export class HttpClient implements Client {
         return this.#promiseLimitFunction(fn);
     }
 
-    async execute(stmt: InStatement): Promise<ResultSet> {
+    async execute(stmt: InStatement): Promise<ResultSet>;
+    async execute(sql: string, args?: InArgs): Promise<ResultSet>;
+
+    async execute(stmtOrSql: InStatement | string, args?: InArgs): Promise<ResultSet> {
+      let stmt: InStatement;
+
+      if (typeof stmtOrSql === 'string') {
+        stmt = {
+            sql: stmtOrSql,
+            args: args || []
+        };
+      } else {
+          stmt = stmtOrSql;
+      }
+
         return this.limit<ResultSet>(async () => {
             try {
                 const isSchemaDatabasePromise = this.getIsSchemaDatabase();

--- a/packages/libsql-client/src/sqlite3.ts
+++ b/packages/libsql-client/src/sqlite3.ts
@@ -12,6 +12,7 @@ import type {
     Value,
     InValue,
     InStatement,
+    InArgs
 } from "@libsql/core/api";
 import { LibsqlError } from "@libsql/core/api";
 import type { ExpandedConfig } from "@libsql/core/config";
@@ -105,7 +106,21 @@ export class Sqlite3Client implements Client {
         this.protocol = "file";
     }
 
-    async execute(stmt: InStatement): Promise<ResultSet> {
+    async execute(stmt: InStatement): Promise<ResultSet>;
+    async execute(sql: string, args?: InArgs): Promise<ResultSet>;
+
+    async execute(stmtOrSql: InStatement | string, args?: InArgs): Promise<ResultSet> {
+      let stmt: InStatement;
+
+      if (typeof stmtOrSql === 'string') {
+        stmt = {
+            sql: stmtOrSql,
+            args: args || []
+        };
+      } else {
+          stmt = stmtOrSql;
+      }
+
         this.#checkNotClosed();
         return executeStmt(this.#getDb(), stmt, this.#intMode);
     }
@@ -192,7 +207,21 @@ export class Sqlite3Transaction implements Transaction {
         this.#intMode = intMode;
     }
 
-    async execute(stmt: InStatement): Promise<ResultSet> {
+    async execute(stmt: InStatement): Promise<ResultSet>;
+        async execute(sql: string, args?: InArgs): Promise<ResultSet>;
+
+        async execute(stmtOrSql: InStatement | string, args?: InArgs): Promise<ResultSet> {
+          let stmt: InStatement;
+
+          if (typeof stmtOrSql === 'string') {
+            stmt = {
+                sql: stmtOrSql,
+                args: args || []
+            };
+          } else {
+              stmt = stmtOrSql;
+          }
+
         this.#checkNotClosed();
         return executeStmt(this.#database, stmt, this.#intMode);
     }

--- a/packages/libsql-client/src/web.ts
+++ b/packages/libsql-client/src/web.ts
@@ -10,25 +10,20 @@ import { _createClient as _createHttpClient } from "./http.js";
 export * from "@libsql/core/api";
 
 export function createClient(config: Config): Client {
-  return _createClient(expandConfig(config, true));
+    return _createClient(expandConfig(config, true));
 }
 
 /** @private */
 export function _createClient(config: ExpandedConfig): Client {
-  console.log("HELLO WORLD FROM WEB");
-  console.log("HELLO WORLD FROM WEB");
-  console.log("HELLO WORLD FROM WEB");
-  console.log("HELLO WORLD FROM WEB");
-
-  if (config.scheme === "ws" || config.scheme === "wss") {
-    return _createWsClient(config);
-  } else if (config.scheme === "http" || config.scheme === "https") {
-    return _createHttpClient(config);
-  } else {
-    throw new LibsqlError(
-      'The client that uses Web standard APIs supports only "libsql:", "wss:", "ws:", "https:" and "http:" URLs, ' +
-        `got ${JSON.stringify(config.scheme + ":")}. For more information, please read ${supportedUrlLink}`,
-      "URL_SCHEME_NOT_SUPPORTED",
-    );
-  }
+    if (config.scheme === "ws" || config.scheme === "wss") {
+        return _createWsClient(config);
+    } else if (config.scheme === "http" || config.scheme === "https") {
+        return _createHttpClient(config);
+    } else {
+        throw new LibsqlError(
+            'The client that uses Web standard APIs supports only "libsql:", "wss:", "ws:", "https:" and "http:" URLs, ' +
+                `got ${JSON.stringify(config.scheme + ":")}. For more information, please read ${supportedUrlLink}`,
+            "URL_SCHEME_NOT_SUPPORTED",
+        );
+    }
 }

--- a/packages/libsql-client/src/web.ts
+++ b/packages/libsql-client/src/web.ts
@@ -10,20 +10,25 @@ import { _createClient as _createHttpClient } from "./http.js";
 export * from "@libsql/core/api";
 
 export function createClient(config: Config): Client {
-    return _createClient(expandConfig(config, true));
+  return _createClient(expandConfig(config, true));
 }
 
 /** @private */
 export function _createClient(config: ExpandedConfig): Client {
-    if (config.scheme === "ws" || config.scheme === "wss") {
-        return _createWsClient(config);
-    } else if (config.scheme === "http" || config.scheme === "https") {
-        return _createHttpClient(config);
-    } else {
-        throw new LibsqlError(
-            'The client that uses Web standard APIs supports only "libsql:", "wss:", "ws:", "https:" and "http:" URLs, ' +
-                `got ${JSON.stringify(config.scheme + ":")}. For more information, please read ${supportedUrlLink}`,
-            "URL_SCHEME_NOT_SUPPORTED",
-        );
-    }
+  console.log("HELLO WORLD FROM WEB");
+  console.log("HELLO WORLD FROM WEB");
+  console.log("HELLO WORLD FROM WEB");
+  console.log("HELLO WORLD FROM WEB");
+
+  if (config.scheme === "ws" || config.scheme === "wss") {
+    return _createWsClient(config);
+  } else if (config.scheme === "http" || config.scheme === "https") {
+    return _createHttpClient(config);
+  } else {
+    throw new LibsqlError(
+      'The client that uses Web standard APIs supports only "libsql:", "wss:", "ws:", "https:" and "http:" URLs, ' +
+        `got ${JSON.stringify(config.scheme + ":")}. For more information, please read ${supportedUrlLink}`,
+      "URL_SCHEME_NOT_SUPPORTED",
+    );
+  }
 }

--- a/packages/libsql-client/src/ws.ts
+++ b/packages/libsql-client/src/ws.ts
@@ -7,6 +7,7 @@ import type {
     Transaction,
     ResultSet,
     InStatement,
+    InArgs
 } from "@libsql/core/api";
 import { TransactionMode, LibsqlError } from "@libsql/core/api";
 import type { ExpandedConfig } from "@libsql/core/config";
@@ -167,7 +168,21 @@ export class WsClient implements Client {
         return this.#promiseLimitFunction(fn);
     }
 
-    async execute(stmt: InStatement): Promise<ResultSet> {
+    async execute(stmt: InStatement): Promise<ResultSet>;
+    async execute(sql: string, args?: InArgs): Promise<ResultSet>;
+
+    async execute(stmtOrSql: InStatement | string, args?: InArgs): Promise<ResultSet> {
+      let stmt: InStatement;
+
+      if (typeof stmtOrSql === 'string') {
+        stmt = {
+            sql: stmtOrSql,
+            args: args || []
+        };
+      } else {
+          stmt = stmtOrSql;
+      }
+
         return this.limit<ResultSet>(async () => {
             const streamState = await this.#openStream();
             try {


### PR DESCRIPTION
Fixes #235 

@penberg @giovannibenussi what if we did something like this? It retains the existing behaviour, while allowing for additional argument `InArgs`:

```ts
client.execute({ sql: "SELECT * FROM users WHERE id = ?", args: [1] })

client.execute("SELECT * FROM users WHERE id = ?", [1])

client.execute("SELECT * FROM users")
```

I haven't refactored, or formatted the files. I didn't seem to find any prettier files. 