### PR TITLE
add tests against sqld in the CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
               run: docker ps
             - name: "Test against sqld"
               run: "npm test"
-              env: { "URL": "ws://localhost:8080", "SERVER": "sqld" }
+              env: { "URL": "http://localhost:8080", "SERVER": "sqld" }
 
     "wasm-test":
         name: "Build and test Wasm on Node.js"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,36 @@ on:
     pull_request:
 
 jobs:
+    "test-against-sqld":
+        name: "Tests against sqld"
+        runs-on: ubuntu-latest
+        timeout-minutes: 2
+        defaults:
+            run:
+                working-directory: ./packages/libsql-client
+        env: { "NODE_OPTIONS": "--trace-warnings" }
+        steps:
+            - name: "Checkout this repo"
+              uses: actions/checkout@v3
+            - name: "Setup Node.js"
+              uses: actions/setup-node@v3
+              with:
+                  node-version: "18.x"
+            - name: "Build core"
+              run: "npm ci && npm run build"
+              working-directory: ./packages/libsql-core
+            - name: "Install npm dependencies"
+              run: "npm ci"
+            - name: "Build"
+              run: "npm run build"
+            - name: Run Docker container in the background
+              run: docker run -d -p 8080:8080 -e SQLD_NODE=primary ghcr.io/tursodatabase/libsql-server:latest
+            - name: Verify container is running
+              run: docker ps
+            - name: "Test against sqld"
+              run: "npm test"
+              env: { "URL": "ws://localhost:8080", "SERVER": "sqld" }
+
     "wasm-test":
         name: "Build and test Wasm on Node.js"
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Context

Current client tests works only against test server which has some feature missing, for example embedded replicas. 

This PR adds tests against latest docker sqld image in the CI and also add simple test for embedded replicas.