### PR TITLE
chore: bump husky and clean up scripts

### DIFF
--- a/.husky/install.mjs
+++ b/.husky/install.mjs
@@ -1,3 +1,4 @@
+// See https://typicode.github.io/husky/how-to.html#ci-server-and-docker
 // Skip Husky install in production and CI
 if (process.env.NODE_ENV === "production" || process.env.CI === "true") {
     process.exit(0);

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npm run lint-staged
+lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,10 @@
                 "packages/libsql-client-wasm"
             ],
             "dependencies": {
-                "husky": "^9.0.11",
                 "lint-staged": "^15.2.2"
+            },
+            "devDependencies": {
+                "husky": "^9.1.5"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -2270,11 +2272,12 @@
             }
         },
         "node_modules/husky": {
-            "version": "9.0.11",
-            "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
-            "integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
+            "version": "9.1.5",
+            "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.5.tgz",
+            "integrity": "sha512-rowAVRUBfI0b4+niA4SJMhfQwc107VLkBUgEYYAOQAbqDCnra1nYh83hF/MDmhYs9t9n1E3DuKOrs2LYNC+0Ag==",
+            "dev": true,
             "bin": {
-                "husky": "bin.mjs"
+                "husky": "bin.js"
             },
             "engines": {
                 "node": ">=18"
@@ -4837,7 +4840,6 @@
             "devDependencies": {
                 "@types/jest": "^29.2.5",
                 "@types/node": "^18.15.5",
-                "husky": "^9.0.11",
                 "jest": "^29.3.1",
                 "lint-staged": "^15.2.2",
                 "msw": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
         "packages/libsql-client",
         "packages/libsql-client-wasm"
     ],
-    "dependencies": {
-        "husky": "^9.0.11",
-        "lint-staged": "^15.2.2"
-    },
+    "dependencies": {},
     "scripts": {
-        "prepare": "node .husky/install.mjs",
-        "lint-staged": "lint-staged"
+        "prepare": "node .husky/install.mjs"
+    },
+    "devDependencies": {
+        "lint-staged": "^15.2.2",
+        "husky": "^9.1.5"
     }
 }

--- a/packages/libsql-client/package.json
+++ b/packages/libsql-client/package.json
@@ -98,7 +98,6 @@
         "test": "jest --runInBand",
         "typecheck": "tsc --noEmit",
         "typedoc": "rm -rf ./docs && typedoc",
-        "prepare": "husky install",
         "lint-staged": "lint-staged"
     },
     "dependencies": {
@@ -111,7 +110,6 @@
     "devDependencies": {
         "@types/jest": "^29.2.5",
         "@types/node": "^18.15.5",
-        "husky": "^9.0.11",
         "jest": "^29.3.1",
         "lint-staged": "^15.2.2",
         "msw": "^2.3.0",


### PR DESCRIPTION
A few minor improvements that might be helpful for #253 :
- Bumping Husky
- Removing Husky from a child package (this will be handled by monorepo setup)
- Some documentation on why `.husky/install.mjs` is present (almost removed it 😅 )
- Simplifying `.husky/pre-commit` (see version [9.1.1](https://github.com/typicode/husky/releases/tag/v9.1.1))
- Simplifying root `package.json`: 
  - Both dependencies are actually dev dependencies
  - `lint-staged` script can be removed as it's directly ran by Husky now