### PR TITLE
chore: format other file types in lint-staged

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,1 +1,1 @@
-{ "*.{js,ts}": "prettier --write" }
+{ "*.{js,ts,json,md,yaml,yml}": "prettier --write" }


### PR DESCRIPTION
Currently lint-staged is skipping other file types that Prettier is [able to format](https://prettier.io/docs/en/).

> Note: Added `.yml` just for future proof.