### PR TITLE
ci: bump github actions to v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,9 +15,9 @@ jobs:
         env: { "NODE_OPTIONS": "--trace-warnings" }
         steps:
             - name: "Checkout this repo"
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: "Setup Node.js"
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: "18.x"
             - name: "Build core"
@@ -45,9 +45,9 @@ jobs:
         env: { "NODE_OPTIONS": "--trace-warnings" }
         steps:
             - name: "Checkout this repo"
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: "Setup Node.js"
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: "18.x"
                   cache-dependency-path: "packages/libsql-client-wasm"
@@ -72,9 +72,9 @@ jobs:
         env: { "NODE_OPTIONS": "--trace-warnings" }
         steps:
             - name: "Checkout this repo"
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: "Setup Node.js"
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: "18.x"
             - name: "Build core"
@@ -83,7 +83,7 @@ jobs:
             - name: "Install npm dependencies"
               run: "npm ci"
             - name: "Checkout hrana-test-server"
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   repository: "libsql/hrana-test-server"
                   path: "packages/libsql-client/hrana-test-server"
@@ -133,9 +133,9 @@ jobs:
             "CLOUDFLARE_ACCOUNT_ID": "${{ secrets.CLOUDFLARE_ACCOUNT_ID }}"
         steps:
             - name: "Checkout this repo"
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: "Setup Node.js"
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: "lts/Hydrogen"
             - name: "Build core"
@@ -145,7 +145,7 @@ jobs:
               run: "npm ci"
 
             - name: "Checkout hrana-test-server"
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   repository: "libsql/hrana-test-server"
                   path: "packages/libsql-client/hrana-test-server"
@@ -201,9 +201,9 @@ jobs:
 #     VERCEL_PROJECT_NAME: "smoke-test"
 #   steps:
 #   - name: "Checkout this repo"
-#     uses: actions/checkout@v3
+#     uses: actions/checkout@v4
 #   - name: "Setup Node.js"
-#     uses: actions/setup-node@v3
+#     uses: actions/setup-node@v4
 #     with:
 #       node-version: "lts/Hydrogen"
 #       cache: "npm"
@@ -211,7 +211,7 @@ jobs:
 #     run: "npm ci"
 
 #   - name: "Checkout hrana-test-server"
-#     uses: actions/checkout@v3
+#     uses: actions/checkout@v4
 #     with:
 #       repository: "libsql/hrana-test-server"
 #       path: "hrana-test-server"

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -12,9 +12,9 @@ jobs:
                 working-directory: ./packages/libsql-client
         steps:
             - name: "Checkout this repo"
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: "Setup Node.js"
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: "${{ matrix.node-version }}"
                   cache: "npm"


### PR DESCRIPTION
```
The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3, actions/setup-node@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default
```

We're getting this warning in CI because of deprecated versions of GH Actions.

Bumping all the actions from `v3` to `v4` 