### PR TITLE
move overloads of execute to @libsql/core/api (because its part of the public API) && add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,13 @@
-
 # Prerequisites
-- have `npm` installed and in path
-- have `git` installed and in path
+
+-   have `npm` installed and in path
+-   have `git` installed and in path
 
 # Setting up the repo for contributing
-- clone this repo (`git clone <this repo's url> libsql-client-ts` on *nix)
-- change the current working directory to the cloned repo (`cd libsql-client-ts` on *nix)
-- `npm i`
-- change the current working directory to `libsql-core`'s workspace (`cd packages/libsql-core` on *nix)
-- build it (`npm run build` on *nix)
-- finally change back to base directory and start experimenting! (`cd ../..` on *nix)
+
+-   clone this repo (`git clone <this repo's url> libsql-client-ts` on \*nix)
+-   change the current working directory to the cloned repo (`cd libsql-client-ts` on \*nix)
+-   `npm i`
+-   change the current working directory to `libsql-core`'s workspace (`cd packages/libsql-core` on \*nix)
+-   build it (`npm run build` on \*nix)
+-   finally change back to base directory and start experimenting! (`cd ../..` on \*nix)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,13 @@
 # Prerequisites
 
--   have `npm` installed and in PATH
--   have `git` installed and in PATH
+-   Have `npm` installed and in PATH
+-   Have `git` installed and in PATH
 
 # Setting up the repo for contributing
 
--   clone this repo (`git clone <this repo's url> libsql-client-ts` on \*nix)
--   change the current working directory to the cloned repo (`cd libsql-client-ts` on \*nix)
--   `npm i`
--   change the current working directory to `libsql-core`'s workspace (`cd packages/libsql-core` on \*nix)
--   build it (`npm run build` on \*nix)
--   finally change back to base directory and start experimenting! (`cd ../..` on \*nix)
+- Clone this repository: `git clone https://github.com/tursodatabase/libsql-client-ts`
+- Change the current working directory to the cloned repository: `cd libsql-client-ts`
+- Install dependencies:  `npm i`
+- Change the current working directory to `libsql-core`'s workspace: `cd packages/libsql-core`
+- Built the core package: `npm run build`
+- Go back to the root directory to start making changes: `cd ../..`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 -   Have `npm` installed and in PATH
 -   Have `git` installed and in PATH
 
-# Setting up the repo for contributing
+# Setting up the repository for contribution
 
 -   Clone this repository: `git clone https://github.com/tursodatabase/libsql-client-ts`
 -   Change the current working directory to the cloned repository: `cd libsql-client-ts`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+
+# Perquisites
+- have `npm` installed and in path
+- have `git` installed and in path
+
+# Setting up the repo for contributing
+- clone this repo (`git clone <this repo's url> libsql-client-ts` on *nix)
+- change the current working directory to the cloned repo (`cd libsql-client-ts` on *nix)
+- `npm i`
+- change the current working directory to `libsql-core`'s workspace (`cd packages/libsql-core` on *nix)
+- build it (`npm run build` on *nix)
+- finally change back to base directory and start experimenting! (`cd ../..` on *nix)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Prerequisites
 
--   have `npm` installed and in path
--   have `git` installed and in path
+-   have `npm` installed and in PATH
+-   have `git` installed and in PATH
 
 # Setting up the repo for contributing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,13 @@
 # Prerequisites
 
-- Have `npm` installed and in PATH
-- Have `git` installed and in PATH
+-   Have `npm` installed and in PATH
+-   Have `git` installed and in PATH
 
 # Setting up the repo for contributing
 
-- Clone this repository: `git clone https://github.com/tursodatabase/libsql-client-ts`
-- Change the current working directory to the cloned repository: `cd libsql-client-ts`
-- Install dependencies:  `npm i`
-- Change the current working directory to `libsql-core`'s workspace: `cd packages/libsql-core`
-- Built the core package: `npm run build`
-- Go back to the root directory to start making changes: `cd ../..`
+-   Clone this repository: `git clone https://github.com/tursodatabase/libsql-client-ts`
+-   Change the current working directory to the cloned repository: `cd libsql-client-ts`
+-   Install dependencies: `npm i`
+-   Change the current working directory to `libsql-core`'s workspace: `cd packages/libsql-core`
+-   Built the core package: `npm run build`
+-   Go back to the root directory to start making changes: `cd ../..`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Prerequisites
 
--   Have `npm` installed and in PATH
--   Have `git` installed and in PATH
+- Have `npm` installed and in PATH
+- Have `git` installed and in PATH
 
 # Setting up the repo for contributing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 
-# Perquisites
+# Prerequisites
 - have `npm` installed and in path
 - have `git` installed and in path
 

--- a/packages/libsql-client-wasm/src/wasm.ts
+++ b/packages/libsql-client-wasm/src/wasm.ts
@@ -123,9 +123,6 @@ export class Sqlite3Client implements Client {
         this.protocol = "file";
     }
 
-    async execute(stmt: InStatement): Promise<ResultSet>;
-    async execute(sql: string, args?: InArgs): Promise<ResultSet>;
-
     async execute(
         stmtOrSql: InStatement | string,
         args?: InArgs,
@@ -171,9 +168,7 @@ export class Sqlite3Client implements Client {
         }
     }
 
-    async migrate(
-        stmts: Array<InStatement>,
-    ): Promise<Array<ResultSet>> {
+    async migrate(stmts: Array<InStatement>): Promise<Array<ResultSet>> {
         this.#checkNotClosed();
         const db = this.#getDb();
         try {

--- a/packages/libsql-client/src/__tests__/client.test.ts
+++ b/packages/libsql-client/src/__tests__/client.test.ts
@@ -814,7 +814,7 @@ describe("batch()", () => {
             );
 
             const n = 100;
-            const promises = [];
+            const promises = [] as Array<any>;
             for (let i = 0; i < n; ++i) {
                 const ii = i;
                 promises.push(
@@ -885,7 +885,7 @@ describe("batch()", () => {
     test(
         "batch with a lot of different statements",
         withClient(async (c) => {
-            const stmts = [];
+            const stmts = [] as Array<any>;
             for (let i = 0; i < 1000; ++i) {
                 stmts.push(`SELECT ${i}`);
             }
@@ -902,7 +902,7 @@ describe("batch()", () => {
             const n = 20;
             const m = 200;
 
-            const stmts = [];
+            const stmts = [] as Array<any>;
             for (let i = 0; i < n; ++i) {
                 for (let j = 0; j < m; ++j) {
                     stmts.push({ sql: `SELECT ?, ${j}`, args: [i] });

--- a/packages/libsql-client/src/hrana.ts
+++ b/packages/libsql-client/src/hrana.ts
@@ -255,7 +255,7 @@ export async function executeHranaBatch(
     disableForeignKeys: boolean = false,
 ): Promise<Array<ResultSet>> {
     if (disableForeignKeys) {
-        batch.step().run("PRAGMA foreign_keys=off")
+        batch.step().run("PRAGMA foreign_keys=off");
     }
     const beginStep = batch.step();
     const beginPromise = beginStep.run(transactionModeToBegin(mode));
@@ -287,7 +287,7 @@ export async function executeHranaBatch(
         .condition(hrana.BatchCond.not(hrana.BatchCond.ok(commitStep)));
     rollbackStep.run("ROLLBACK").catch((_) => undefined);
     if (disableForeignKeys) {
-        batch.step().run("PRAGMA foreign_keys=on")
+        batch.step().run("PRAGMA foreign_keys=on");
     }
 
     await batch.execute();

--- a/packages/libsql-client/src/http.ts
+++ b/packages/libsql-client/src/http.ts
@@ -96,9 +96,6 @@ export class HttpClient implements Client {
         return this.#promiseLimitFunction(fn);
     }
 
-    async execute(stmt: InStatement): Promise<ResultSet>;
-    async execute(sql: string, args?: InArgs): Promise<ResultSet>;
-
     async execute(
         stmtOrSql: InStatement | string,
         args?: InArgs,
@@ -180,9 +177,7 @@ export class HttpClient implements Client {
         });
     }
 
-    async migrate(
-        stmts: Array<InStatement>,
-    ): Promise<Array<ResultSet>> {
+    async migrate(stmts: Array<InStatement>): Promise<Array<ResultSet>> {
         return this.limit<Array<ResultSet>>(async () => {
             try {
                 const hranaStmts = stmts.map(stmtToHrana);

--- a/packages/libsql-client/src/sqlite3.ts
+++ b/packages/libsql-client/src/sqlite3.ts
@@ -119,9 +119,6 @@ export class Sqlite3Client implements Client {
         this.protocol = "file";
     }
 
-    async execute(stmt: InStatement): Promise<ResultSet>;
-    async execute(sql: string, args?: InArgs): Promise<ResultSet>;
-
     async execute(
         stmtOrSql: InStatement | string,
         args?: InArgs,
@@ -167,9 +164,7 @@ export class Sqlite3Client implements Client {
         }
     }
 
-    async migrate(
-        stmts: Array<InStatement>,
-    ): Promise<Array<ResultSet>> {
+    async migrate(stmts: Array<InStatement>): Promise<Array<ResultSet>> {
         this.#checkNotClosed();
         const db = this.#getDb();
         try {

--- a/packages/libsql-client/src/ws.ts
+++ b/packages/libsql-client/src/ws.ts
@@ -154,9 +154,6 @@ export class WsClient implements Client {
         return this.#promiseLimitFunction(fn);
     }
 
-    async execute(stmt: InStatement): Promise<ResultSet>;
-    async execute(sql: string, args?: InArgs): Promise<ResultSet>;
-
     async execute(
         stmtOrSql: InStatement | string,
         args?: InArgs,
@@ -226,9 +223,7 @@ export class WsClient implements Client {
         });
     }
 
-    async migrate(
-        stmts: Array<InStatement>,
-    ): Promise<Array<ResultSet>> {
+    async migrate(stmts: Array<InStatement>): Promise<Array<ResultSet>> {
         return this.limit<Array<ResultSet>>(async () => {
             const streamState = await this.#openStream();
             try {

--- a/packages/libsql-core/src/api.ts
+++ b/packages/libsql-core/src/api.ts
@@ -87,6 +87,7 @@ export interface Client {
      * ```
      */
     execute(stmt: InStatement): Promise<ResultSet>;
+    execute(sql: string, args?: InArgs): Promise<ResultSet>;
 
     /** Execute a batch of SQL statements in a transaction.
      *
@@ -155,9 +156,7 @@ export interface Client {
      * ]);
      * ```
      */
-    migrate(
-        stmts: Array<InStatement>,
-    ): Promise<Array<ResultSet>>;
+    migrate(stmts: Array<InStatement>): Promise<Array<ResultSet>>;
 
     /** Start an interactive transaction.
      *


### PR DESCRIPTION
move overloads of execute to @libsql/core/api (because its part of the public API)
and
add CONTRIBUTING.md to provide instructions to setup repo for experimentation and contribution