### PR TITLE
upgrade libsql-js: 0.4.1 -> 0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.11.0 -- 2024-09-13
+
+-   Upgrade `libsql-js` to latest 0.4.4 version which brings full vector search support for embedded replicas (see vector search documentation here: https://docs.turso.tech/features/ai-and-embeddings)
+
 ## 0.10.0 -- 2024-08-26
 
 -   Add a migrate() API that can be used to do migrations on both schema databases and regular databases. It is mostly dedicated to schema migration tools.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1048,9 +1048,9 @@
             "link": true
         },
         "node_modules/@libsql/darwin-arm64": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@libsql/darwin-arm64/-/darwin-arm64-0.4.1.tgz",
-            "integrity": "sha512-XICT9/OyU8Aa9Iv1xZIHgvM09n/1OQUk3VC+s5uavzdiGHrDMkOWzN47JN7/FiMa/NWrcgoEiDMk3+e7mE53Ig==",
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/@libsql/darwin-arm64/-/darwin-arm64-0.4.4.tgz",
+            "integrity": "sha512-2JauQh/A5KNBO5FAeZpeZ12v+OtNBSBwN2fHq6q59dpVL0Jfe5CsYWIlKxionN/0R8QxHumQw4QWqrhqtlE9Vg==",
             "cpu": [
                 "arm64"
             ],
@@ -1060,9 +1060,9 @@
             ]
         },
         "node_modules/@libsql/darwin-x64": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@libsql/darwin-x64/-/darwin-x64-0.4.1.tgz",
-            "integrity": "sha512-pSKxhRrhu4SsTD+IBRZXcs1SkwMdeAG1tv6Z/Ctp/sOEYrgkU8MDKLqkOr9NsmwpK4S0+JdwjkLMyhTkct/5TQ==",
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/@libsql/darwin-x64/-/darwin-x64-0.4.4.tgz",
+            "integrity": "sha512-Yajb7sp0hZ5d9w4ZXojTu2mC7oFQ7U+IVfq5X8pSTa7uOBpxpQ4H5CQcawA3r0vDnVoS+li32bIrqaGiyAvNsQ==",
             "cpu": [
                 "x64"
             ],
@@ -1104,9 +1104,9 @@
             }
         },
         "node_modules/@libsql/linux-arm64-gnu": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-gnu/-/linux-arm64-gnu-0.4.1.tgz",
-            "integrity": "sha512-9lpvb24tO2qZd9nq5dlq3ESA3hSKYWBIK7lJjfiCM6f7a70AUwBY9QoPJV9q4gILIyVnR1YBGrlm50nnb+dYgw==",
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-gnu/-/linux-arm64-gnu-0.4.4.tgz",
+            "integrity": "sha512-lAsuCpfnS6Cr7IOjDsRFAC3vfouJm3G/Rz14nLNxGKIQV/rWX7wLFKIxYvwFQQvw0f7VdJwjUg1rkq9kGOMBTA==",
             "cpu": [
                 "arm64"
             ],
@@ -1116,9 +1116,9 @@
             ]
         },
         "node_modules/@libsql/linux-arm64-musl": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-musl/-/linux-arm64-musl-0.4.1.tgz",
-            "integrity": "sha512-lyxi+lFxE+NcBRDMQCxCtDg3c4WcKAbc9u63d5+B23Vm+UgphD9XY4seu+tGrBy1MU2tuNVix7r9S7ECpAaVrA==",
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-musl/-/linux-arm64-musl-0.4.4.tgz",
+            "integrity": "sha512-Icp1HY5gLB2fsOsnbh9sAz++dXipedoH3LI/BRHDFXlCvm2Ph45Sy9gOYOFUfNq3SZKOuy1cqVvQremySiElmg==",
             "cpu": [
                 "arm64"
             ],
@@ -1128,9 +1128,9 @@
             ]
         },
         "node_modules/@libsql/linux-x64-gnu": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@libsql/linux-x64-gnu/-/linux-x64-gnu-0.4.1.tgz",
-            "integrity": "sha512-psvuQ3UFBEmDFV8ZHG+WkUHIJiWv+elZ+zIPvOVedlIKdxG1O+8WthWUAhFHOGnbiyzc4sAZ4c3de1oCvyHxyQ==",
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/@libsql/linux-x64-gnu/-/linux-x64-gnu-0.4.4.tgz",
+            "integrity": "sha512-ZRMAjMEo2TdbppfqHXkvzh7iWb4OxjA4ZTcxMIP7745eJocIarexHHYR4GHVp3e3sqiM7Wg63EnvQ9dSLQM4PQ==",
             "cpu": [
                 "x64"
             ],
@@ -1140,9 +1140,9 @@
             ]
         },
         "node_modules/@libsql/linux-x64-musl": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@libsql/linux-x64-musl/-/linux-x64-musl-0.4.1.tgz",
-            "integrity": "sha512-PDidJ3AhGDqosGg3OAZzGxMFIbnuOALya4BoezJKl667AFv3x7BBQ30H81Mngsq3Fh8RkJkXSdWfL91+Txb1iA==",
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/@libsql/linux-x64-musl/-/linux-x64-musl-0.4.4.tgz",
+            "integrity": "sha512-bRVqiBcRNsr7it23258sTP+NR3Pr1DmcLCbporyYFYeCxYNEFQXHd2JDWaGNqqu2iBEOp/P2nrjizSOlp5aCMQ==",
             "cpu": [
                 "x64"
             ],
@@ -1152,9 +1152,9 @@
             ]
         },
         "node_modules/@libsql/win32-x64-msvc": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@libsql/win32-x64-msvc/-/win32-x64-msvc-0.4.1.tgz",
-            "integrity": "sha512-IdODVqV/PrdOnHA/004uWyorZQuRsB7U7bCRCE3vXgABj3eJLJGc6cv2C6ksEaEoVxJbD8k53H4VVAGrtYwXzQ==",
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/@libsql/win32-x64-msvc/-/win32-x64-msvc-0.4.4.tgz",
+            "integrity": "sha512-Snqk2CB1uHL2dDtGizJEQR3oY5zWHRroXBp90J9VmMeZgqwfU+Ivgj1WaFzz980efxsPvqK1BoFxqG316BksjA==",
             "cpu": [
                 "x64"
             ],
@@ -3101,9 +3101,9 @@
             }
         },
         "node_modules/libsql": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/libsql/-/libsql-0.4.1.tgz",
-            "integrity": "sha512-qZlR9Yu1zMBeLChzkE/cKfoKV3Esp9cn9Vx5Zirn4AVhDWPcjYhKwbtJcMuHehgk3mH+fJr9qW+3vesBWbQpBg==",
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/libsql/-/libsql-0.4.4.tgz",
+            "integrity": "sha512-Ub1YDlfAKOst9xoHMOb1dhgcu8qkMP6IM+xZoEptQuPtFe+w3ShRvJMa9FvI7FI5EEG/B4FXLLXPS9utMQq5xQ==",
             "cpu": [
                 "x64",
                 "arm64",
@@ -3116,131 +3116,17 @@
             ],
             "dependencies": {
                 "@neon-rs/load": "^0.0.4",
-                "detect-libc": "2.0.2",
-                "libsql": "^0.3.19"
+                "detect-libc": "2.0.2"
             },
             "optionalDependencies": {
-                "@libsql/darwin-arm64": "0.4.1",
-                "@libsql/darwin-x64": "0.4.1",
-                "@libsql/linux-arm64-gnu": "0.4.1",
-                "@libsql/linux-arm64-musl": "0.4.1",
-                "@libsql/linux-x64-gnu": "0.4.1",
-                "@libsql/linux-x64-musl": "0.4.1",
-                "@libsql/win32-x64-msvc": "0.4.1"
+                "@libsql/darwin-arm64": "0.4.4",
+                "@libsql/darwin-x64": "0.4.4",
+                "@libsql/linux-arm64-gnu": "0.4.4",
+                "@libsql/linux-arm64-musl": "0.4.4",
+                "@libsql/linux-x64-gnu": "0.4.4",
+                "@libsql/linux-x64-musl": "0.4.4",
+                "@libsql/win32-x64-msvc": "0.4.4"
             }
-        },
-        "node_modules/libsql/node_modules/libsql": {
-            "version": "0.3.19",
-            "resolved": "https://registry.npmjs.org/libsql/-/libsql-0.3.19.tgz",
-            "integrity": "sha512-Aj5cQ5uk/6fHdmeW0TiXK42FqUlwx7ytmMLPSaUQPin5HKKKuUPD62MAbN4OEweGBBI7q1BekoEN4gPUEL6MZA==",
-            "cpu": [
-                "x64",
-                "arm64",
-                "wasm32"
-            ],
-            "os": [
-                "darwin",
-                "linux",
-                "win32"
-            ],
-            "dependencies": {
-                "@neon-rs/load": "^0.0.4",
-                "detect-libc": "2.0.2",
-                "libsql": "^0.3.15"
-            },
-            "optionalDependencies": {
-                "@libsql/darwin-arm64": "0.3.19",
-                "@libsql/darwin-x64": "0.3.19",
-                "@libsql/linux-arm64-gnu": "0.3.19",
-                "@libsql/linux-arm64-musl": "0.3.19",
-                "@libsql/linux-x64-gnu": "0.3.19",
-                "@libsql/linux-x64-musl": "0.3.19",
-                "@libsql/win32-x64-msvc": "0.3.19"
-            }
-        },
-        "node_modules/libsql/node_modules/libsql/node_modules/@libsql/darwin-arm64": {
-            "version": "0.3.19",
-            "resolved": "https://registry.npmjs.org/@libsql/darwin-arm64/-/darwin-arm64-0.3.19.tgz",
-            "integrity": "sha512-rmOqsLcDI65zzxlUOoEiPJLhqmbFsZF6p4UJQ2kMqB+Kc0Rt5/A1OAdOZ/Wo8fQfJWjR1IbkbpEINFioyKf+nQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "darwin"
-            ]
-        },
-        "node_modules/libsql/node_modules/libsql/node_modules/@libsql/darwin-x64": {
-            "version": "0.3.19",
-            "resolved": "https://registry.npmjs.org/@libsql/darwin-x64/-/darwin-x64-0.3.19.tgz",
-            "integrity": "sha512-q9O55B646zU+644SMmOQL3FIfpmEvdWpRpzubwFc2trsa+zoBlSkHuzU9v/C+UNoPHQVRMP7KQctJ455I/h/xw==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "darwin"
-            ]
-        },
-        "node_modules/libsql/node_modules/libsql/node_modules/@libsql/linux-arm64-gnu": {
-            "version": "0.3.19",
-            "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-gnu/-/linux-arm64-gnu-0.3.19.tgz",
-            "integrity": "sha512-mgeAUU1oqqh57k7I3cQyU6Trpdsdt607eFyEmH5QO7dv303ti+LjUvh1pp21QWV6WX7wZyjeJV1/VzEImB+jRg==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/libsql/node_modules/libsql/node_modules/@libsql/linux-arm64-musl": {
-            "version": "0.3.19",
-            "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-musl/-/linux-arm64-musl-0.3.19.tgz",
-            "integrity": "sha512-VEZtxghyK6zwGzU9PHohvNxthruSxBEnRrX7BSL5jQ62tN4n2JNepJ6SdzXp70pdzTfwroOj/eMwiPt94gkVRg==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/libsql/node_modules/libsql/node_modules/@libsql/linux-x64-gnu": {
-            "version": "0.3.19",
-            "resolved": "https://registry.npmjs.org/@libsql/linux-x64-gnu/-/linux-x64-gnu-0.3.19.tgz",
-            "integrity": "sha512-2t/J7LD5w2f63wGihEO+0GxfTyYIyLGEvTFEsMO16XI5o7IS9vcSHrxsvAJs4w2Pf907uDjmc7fUfMg6L82BrQ==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/libsql/node_modules/libsql/node_modules/@libsql/linux-x64-musl": {
-            "version": "0.3.19",
-            "resolved": "https://registry.npmjs.org/@libsql/linux-x64-musl/-/linux-x64-musl-0.3.19.tgz",
-            "integrity": "sha512-BLsXyJaL8gZD8+3W2LU08lDEd9MIgGds0yPy5iNPp8tfhXx3pV/Fge2GErN0FC+nzt4DYQtjL+A9GUMglQefXQ==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/libsql/node_modules/libsql/node_modules/@libsql/win32-x64-msvc": {
-            "version": "0.3.19",
-            "resolved": "https://registry.npmjs.org/@libsql/win32-x64-msvc/-/win32-x64-msvc-0.3.19.tgz",
-            "integrity": "sha512-ay1X9AobE4BpzG0XPw1gplyLZPGHIgJOovvW23gUrukRegiUP62uzhpRbKNogLlUOynyXeq//prHgPXiebUfWg==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "win32"
-            ]
         },
         "node_modules/lilconfig": {
             "version": "3.0.0",
@@ -4831,7 +4717,7 @@
                 "@libsql/core": "^0.10.0",
                 "@libsql/hrana-client": "^0.6.2",
                 "js-base64": "^3.7.5",
-                "libsql": "^0.4.1",
+                "libsql": "^0.4.4",
                 "promise-limit": "^2.7.0"
             },
             "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4711,10 +4711,10 @@
         },
         "packages/libsql-client": {
             "name": "@libsql/client",
-            "version": "0.10.0",
+            "version": "0.11.0",
             "license": "MIT",
             "dependencies": {
-                "@libsql/core": "^0.10.0",
+                "@libsql/core": "^0.11.0",
                 "@libsql/hrana-client": "^0.6.2",
                 "js-base64": "^3.7.5",
                 "libsql": "^0.4.4",
@@ -4735,13 +4735,13 @@
         },
         "packages/libsql-client-wasm": {
             "name": "@libsql/client-wasm",
-            "version": "0.10.0",
+            "version": "0.11.0",
             "bundleDependencies": [
                 "@libsql/libsql-wasm-experimental"
             ],
             "license": "MIT",
             "dependencies": {
-                "@libsql/core": "^0.10.0",
+                "@libsql/core": "^0.11.0",
                 "@libsql/libsql-wasm-experimental": "^0.0.2",
                 "js-base64": "^3.7.5"
             },
@@ -4755,7 +4755,7 @@
         },
         "packages/libsql-core": {
             "name": "@libsql/core",
-            "version": "0.10.0",
+            "version": "0.11.0",
             "license": "MIT",
             "dependencies": {
                 "js-base64": "^3.7.5"

--- a/packages/libsql-client-wasm/package.json
+++ b/packages/libsql-client-wasm/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@libsql/client-wasm",
-    "version": "0.10.0",
+    "version": "0.11.0",
     "keywords": [
         "libsql",
         "database",
@@ -56,7 +56,7 @@
         "typedoc": "rm -rf ./docs && typedoc"
     },
     "dependencies": {
-        "@libsql/core": "^0.10.0",
+        "@libsql/core": "^0.11.0",
         "@libsql/libsql-wasm-experimental": "^0.0.2",
         "js-base64": "^3.7.5"
     },

--- a/packages/libsql-client/examples/sync_vector.js
+++ b/packages/libsql-client/examples/sync_vector.js
@@ -1,0 +1,51 @@
+import { createClient } from "@libsql/client";
+import reader from "readline-sync";
+
+async function example() {
+    const config = {
+        url: process.env.URL ?? "file:local.db",
+        syncUrl: process.env.SYNC_URL,
+        authToken: process.env.AUTH_TOKEN,
+    };
+    const db = createClient(config);
+    await db.sync();
+    await db.execute(
+        "CREATE TABLE IF NOT EXISTS movies (title TEXT, embedding FLOAT32(4))",
+    );
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS movies_idx ON movies (libsql_vector_idx(embedding))",
+    );
+    await db.sync();
+
+    const title = reader.question("Add movie (title): ");
+    const embedding = reader.question(
+        "Add movie (embedding, e.g. [1,2,3,4]): ",
+    );
+
+    await db.execute({
+        sql: "INSERT INTO movies (title, embedding) VALUES (?, vector32(?))",
+        args: [title, embedding],
+    });
+
+    await db.sync();
+
+    const all = await db.execute(
+        "SELECT title, vector_extract(embedding) as embedding FROM movies",
+    );
+    console.info("all movies:");
+    for (const row of all.rows) {
+        console.log(" - " + row.title + ": " + row.embedding);
+    }
+
+    const query = reader.question("KNN query (e.g. [1,2,3,4]): ");
+    const nn = await db.execute({
+        sql: "SELECT title, vector_extract(embedding) as embedding FROM vector_top_k('movies_idx', vector32(?), 2) as knn JOIN movies ON knn.id = movies.rowid",
+        args: [query],
+    });
+    console.info("nearest neighbors:");
+    for (const row of nn.rows) {
+        console.log(" - " + row.title + ": " + row.embedding);
+    }
+}
+
+example();

--- a/packages/libsql-client/package.json
+++ b/packages/libsql-client/package.json
@@ -105,7 +105,7 @@
         "@libsql/core": "^0.10.0",
         "@libsql/hrana-client": "^0.6.2",
         "js-base64": "^3.7.5",
-        "libsql": "^0.4.1",
+        "libsql": "^0.4.4",
         "promise-limit": "^2.7.0"
     },
     "devDependencies": {

--- a/packages/libsql-client/package.json
+++ b/packages/libsql-client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@libsql/client",
-    "version": "0.10.0",
+    "version": "0.11.0",
     "keywords": [
         "libsql",
         "database",
@@ -102,7 +102,7 @@
         "lint-staged": "lint-staged"
     },
     "dependencies": {
-        "@libsql/core": "^0.10.0",
+        "@libsql/core": "^0.11.0",
         "@libsql/hrana-client": "^0.6.2",
         "js-base64": "^3.7.5",
         "libsql": "^0.4.4",

--- a/packages/libsql-core/package.json
+++ b/packages/libsql-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@libsql/core",
-    "version": "0.10.0",
+    "version": "0.11.0",
     "keywords": [
         "libsql",
         "database",


### PR DESCRIPTION
We need latest version of `libsql-js` to have full vector support in embedded replicas

This PR also adds simple example with vector feature in embedded replica.