### PR TITLE
setup CI for publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
             working-directory: ./packages/libsql-client
     env:
       NODE_OPTIONS: "--trace-warnings"
-#      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
         - name: "Checkout this repo"
           uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
             working-directory: ./packages/libsql-client
     env:
       NODE_OPTIONS: "--trace-warnings"
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
         - name: "Checkout this repo"
           uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,44 @@
+name: publish
+
+env:
+  NPM_REGISTRY: 'https://registry.npmjs.org'
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  publish-to-npm:
+    name: "Publish new version to NPM"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    defaults:
+        run:
+            working-directory: ./packages/libsql-client
+    env:
+      NODE_OPTIONS: "--trace-warnings"
+#      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    steps:
+        - name: "Checkout this repo"
+          uses: actions/checkout@v3
+
+        - name: "Setup Node.js"
+          uses: actions/setup-node@v3
+          with:
+              node-version: "18.x"
+
+        - name: "Build core"
+          run: "npm ci && npm run build"
+          working-directory: ./packages/libsql-core
+
+        - name: "Install npm dependencies"
+          run: "npm ci"
+
+        - name: "Publish pre-release version"
+          if: contains(github.ref, '-pre')
+          run: "npm publish --tag next"
+
+        - name: "Publish latest version"
+          if: "!contains(github.ref, '-pre')"
+          run: "npm publish"

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4716,10 +4716,10 @@
         },
         "packages/libsql-client": {
             "name": "@libsql/client",
-            "version": "0.12.0",
+            "version": "0.12.1-pre.1",
             "license": "MIT",
             "dependencies": {
-                "@libsql/core": "^0.12.0",
+                "@libsql/core": "^0.12.1-pre.1",
                 "@libsql/hrana-client": "^0.7.0",
                 "js-base64": "^3.7.5",
                 "libsql": "^0.4.4",
@@ -4740,13 +4740,13 @@
         },
         "packages/libsql-client-wasm": {
             "name": "@libsql/client-wasm",
-            "version": "0.12.0",
+            "version": "0.12.1-pre.1",
             "bundleDependencies": [
                 "@libsql/libsql-wasm-experimental"
             ],
             "license": "MIT",
             "dependencies": {
-                "@libsql/core": "^0.12.0",
+                "@libsql/core": "^0.12.1-pre.1",
                 "@libsql/libsql-wasm-experimental": "^0.0.2",
                 "js-base64": "^3.7.5"
             },
@@ -4760,7 +4760,7 @@
         },
         "packages/libsql-core": {
             "name": "@libsql/core",
-            "version": "0.12.0",
+            "version": "0.12.1-pre.1",
             "license": "MIT",
             "dependencies": {
                 "js-base64": "^3.7.5"

--- a/packages/libsql-client-wasm/package.json
+++ b/packages/libsql-client-wasm/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@libsql/client-wasm",
-    "version": "0.12.0",
+    "version": "0.12.1-pre.1",
     "keywords": [
         "libsql",
         "database",
@@ -56,7 +56,7 @@
         "typedoc": "rm -rf ./docs && typedoc"
     },
     "dependencies": {
-        "@libsql/core": "^0.12.0",
+        "@libsql/core": "^0.12.1-pre.1",
         "@libsql/libsql-wasm-experimental": "^0.0.2",
         "js-base64": "^3.7.5"
     },

--- a/packages/libsql-client/package.json
+++ b/packages/libsql-client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@libsql/client",
-    "version": "0.12.0",
+    "version": "0.12.1-pre.1",
     "keywords": [
         "libsql",
         "database",
@@ -102,7 +102,7 @@
         "lint-staged": "lint-staged"
     },
     "dependencies": {
-        "@libsql/core": "^0.12.0",
+        "@libsql/core": "^0.12.1-pre.1",
         "@libsql/hrana-client": "^0.7.0",
         "js-base64": "^3.7.5",
         "libsql": "^0.4.4",

--- a/packages/libsql-core/package.json
+++ b/packages/libsql-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@libsql/core",
-    "version": "0.12.0",
+    "version": "0.12.1-pre.1",
     "keywords": [
         "libsql",
         "database",


### PR DESCRIPTION
Setup CI for automatic publish of NPM package based on the tag:

- Tags matching `v*` pattern with `-pre` substring will be published as pre-release versions (`npm publish --tag next`)
- All other tags matching `v*` pattern will be published as latest package version (`npm publish`)