### PR TITLE
chore: add git+ prefix to repo url in package.json

### DIFF
--- a/packages/libsql-client-wasm/package.json
+++ b/packages/libsql-client-wasm/package.json
@@ -13,7 +13,8 @@
     "description": "libSQL driver for TypeScript and JavaScript",
     "repository": {
         "type": "git",
-        "url": "https://github.com/libsql/libsql-client-ts"
+        "url": "git+https://github.com/libsql/libsql-client-ts",
+        "directory": "packages/libsql-client-wasm"
     },
     "authors": [
         "Jan Špaček <honza@chiselstrike.com>",

--- a/packages/libsql-client/package.json
+++ b/packages/libsql-client/package.json
@@ -13,7 +13,8 @@
     "description": "libSQL driver for TypeScript and JavaScript",
     "repository": {
         "type": "git",
-        "url": "https://github.com/libsql/libsql-client-ts"
+        "url": "git+https://github.com/libsql/libsql-client-ts",
+        "directory": "packages/libsql-client"
     },
     "authors": [
         "Jan Špaček <honza@chiselstrike.com>",

--- a/packages/libsql-core/package.json
+++ b/packages/libsql-core/package.json
@@ -13,7 +13,8 @@
     "description": "libSQL driver for TypeScript and JavaScript",
     "repository": {
         "type": "git",
-        "url": "https://github.com/libsql/libsql-client-ts"
+        "url": "git+https://github.com/libsql/libsql-client-ts",
+        "directory": "packages/libsql-core"
     },
     "authors": [
         "Jan Špaček <honza@chiselstrike.com>",


### PR DESCRIPTION
While investigating [tsup](https://tsup.egoist.dev/) as a solution, I first checked if the libraries were correctly published by using:
- [publint](https://publint.dev/@libsql/client@0.11.0)
- [aretypeswrong](https://arethetypeswrong.github.io/?p=@libsql/client@0.11.0)

I noticed a small issue with the rule [`INVALID_RESOSITORY_VALUE`](https://publint.dev/rules#invalid_repository_value).

This PR aims to fix it.