### PR TITLE
upgrade hrana-client-ts: 0.6.2 -> 0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1072,20 +1072,25 @@
             ]
         },
         "node_modules/@libsql/hrana-client": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/@libsql/hrana-client/-/hrana-client-0.6.2.tgz",
-            "integrity": "sha512-MWxgD7mXLNf9FXXiM0bc90wCjZSpErWKr5mGza7ERy2FJNNMXd7JIOv+DepBA1FQTIfI8TFO4/QDYgaQC0goNw==",
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@libsql/hrana-client/-/hrana-client-0.7.0.tgz",
+            "integrity": "sha512-OF8fFQSkbL7vJY9rfuegK1R7sPgQ6kFMkDamiEccNUvieQ+3urzfDFI616oPl8V7T9zRmnTkSjMOImYCAVRVuw==",
+            "license": "MIT",
             "dependencies": {
-                "@libsql/isomorphic-fetch": "^0.2.1",
+                "@libsql/isomorphic-fetch": "^0.3.1",
                 "@libsql/isomorphic-ws": "^0.1.5",
                 "js-base64": "^3.7.5",
                 "node-fetch": "^3.3.2"
             }
         },
         "node_modules/@libsql/isomorphic-fetch": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/@libsql/isomorphic-fetch/-/isomorphic-fetch-0.2.1.tgz",
-            "integrity": "sha512-Sv07QP1Aw8A5OOrmKgRUBKe2fFhF2hpGJhtHe3d1aRnTESZCGkn//0zDycMKTGamVWb3oLYRroOsCV8Ukes9GA=="
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@libsql/isomorphic-fetch/-/isomorphic-fetch-0.3.1.tgz",
+            "integrity": "sha512-6kK3SUK5Uu56zPq/Las620n5aS9xJq+jMBcNSOmjhNf/MUvdyji4vrMTqD7ptY7/4/CAVEAYDeotUz60LNQHtw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.0.0"
+            }
         },
         "node_modules/@libsql/isomorphic-ws": {
             "version": "0.1.5",
@@ -4715,7 +4720,7 @@
             "license": "MIT",
             "dependencies": {
                 "@libsql/core": "^0.11.0",
-                "@libsql/hrana-client": "^0.6.2",
+                "@libsql/hrana-client": "^0.7.0",
                 "js-base64": "^3.7.5",
                 "libsql": "^0.4.4",
                 "promise-limit": "^2.7.0"

--- a/packages/libsql-client/package.json
+++ b/packages/libsql-client/package.json
@@ -103,7 +103,7 @@
     },
     "dependencies": {
         "@libsql/core": "^0.11.0",
-        "@libsql/hrana-client": "^0.6.2",
+        "@libsql/hrana-client": "^0.7.0",
         "js-base64": "^3.7.5",
         "libsql": "^0.4.4",
         "promise-limit": "^2.7.0"


### PR DESCRIPTION
- this leads to upgrade of isomorphic-fetch to 0.3.1