### PR TITLE
update ci to run example in deno and fix it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -152,6 +152,50 @@ jobs:
               run: "cd examples && npm i && node example.js"
               env: { "URL": "file:///tmp/example.db" }
 
+    "deno-test":
+        name: "Build on Node.js and test on Deno"
+        runs-on: ubuntu-latest
+        timeout-minutes: 2
+        defaults:
+            run:
+                working-directory: ./packages/libsql-client
+        env: { "NODE_OPTIONS": "--trace-warnings" }
+        steps:
+            - name: "Checkout this repo"
+              uses: actions/checkout@v4
+            - name: "Setup Node.js"
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "18.x"
+            - name: "Build core"
+              run: "npm ci && npm run build"
+              working-directory: ./packages/libsql-core
+            - name: "Install npm dependencies"
+              run: "npm ci"
+            - name: "Checkout hrana-test-server"
+              uses: actions/checkout@v4
+              with:
+                  repository: "libsql/hrana-test-server"
+                  path: "packages/libsql-client/hrana-test-server"
+            - name: "Setup Python"
+              uses: actions/setup-python@v4
+              with:
+                  python-version: "3.10"
+            - name: "Install pip dependencies"
+              run: "pip install -r hrana-test-server/requirements.txt"
+
+            - name: "Build"
+              run: "npm run build"
+
+            - name: "Setup Deno"
+              uses: denolib/setup-deno@v2
+              with:
+                  deno-version: "2.x"
+
+            - name: "Test example"
+              run: cd examples && deno -ERS --allow-ffi example.js
+              env: { "URL": "file:///tmp/example.db" }
+
     "workers-test":
         name: "Build and test with Cloudflare Workers"
         if: false

--- a/packages/libsql-client/package.json
+++ b/packages/libsql-client/package.json
@@ -30,7 +30,7 @@
             "types": "./lib-esm/node.d.ts",
             "import": {
                 "workerd": "./lib-esm/web.js",
-                "deno": "./lib-esm/web.js",
+                "deno": "./lib-esm/node.js",
                 "edge-light": "./lib-esm/web.js",
                 "netlify": "./lib-esm/web.js",
                 "node": "./lib-esm/node.js",


### PR DESCRIPTION
refs #138 

changes:
- add test for deno to run example script in ci
- to allow deno to use local file or `:memory:` simply use `lib-esm/node.js` instead of `./lib-esm/web.js`

enables:
- deno to run on local db file or `:memory:` as node.js

downside:
- requires `--allow-ffi` flag to run since `lib-esm/node.js` imports [createClient function from sqlite3](https://github.com/tursodatabase/libsql-client-ts/blob/9e6b5b8bb13701bd60d6d06641922d878163b216/packages/libsql-client/src/node.ts#L5)