### PR TITLE
Close database connections referenced in transaction.

### DIFF
--- a/packages/libsql-client/src/sqlite3.ts
+++ b/packages/libsql-client/src/sqlite3.ts
@@ -247,11 +247,13 @@ export class Sqlite3Client implements Client {
 export class Sqlite3Transaction implements Transaction {
     #database: Database.Database;
     #intMode: IntMode;
+    #dbClosed: boolean;
 
     /** @private */
     constructor(database: Database.Database, intMode: IntMode) {
         this.#database = database;
         this.#intMode = intMode;
+        this.#dbClosed = false;
     }
 
     async execute(stmt: InStatement): Promise<ResultSet>;
@@ -307,8 +309,19 @@ export class Sqlite3Transaction implements Transaction {
     }
 
     close(): void {
-        if (this.#database.inTransaction) {
-            executeStmt(this.#database, "ROLLBACK", this.#intMode);
+        try {
+            if (this.#database.inTransaction) {
+                executeStmt(this.#database, "ROLLBACK", this.#intMode);
+            }
+        } finally {
+            this.#dbClose();
+        }
+    }
+
+    #dbClose(): void {
+        if (!this.#dbClosed) {
+            this.#dbClosed = true;
+            this.#database.close();
         }
     }
 


### PR DESCRIPTION
It does not fix, but at least gives a user a chance to handle the problem. 

https://github.com/tursodatabase/libsql-client-ts/issues/309

I'm not sure how to test it as it happens only on windows machines. 

I was wondering if closing the database connection shouldn't be done in all of: commit / rollback / close.

I've updated the transaction example, documentation suggests a pattern in which transactions are closed in finally block, but example was not following that.
