### PR TITLE
Deno should use the node lib rather than web

### DIFF
--- a/packages/libsql-client/package.json
+++ b/packages/libsql-client/package.json
@@ -30,7 +30,7 @@
             "types": "./lib-esm/node.d.ts",
             "import": {
                 "workerd": "./lib-esm/web.js",
-                "deno": "./lib-esm/web.js",
+                "deno": "./lib-esm/node.js",
                 "edge-light": "./lib-esm/web.js",
                 "netlify": "./lib-esm/web.js",
                 "node": "./lib-esm/node.js",


### PR DESCRIPTION
This PR changes the Deno export in package.json to use the Node.js implementation instead of the web implementation.

Deno's runtime environment more closely aligns with Node.js APIs for this particular library. While Deno typically uses web-standard APIs, our testing revealed that the Node.js implementation provides better compatibility and performance for Deno users in this specific case.

This should give improved compatibility for Deno users, and fix issues where file system access is not available.