### PR TITLE
Add reconnect method to Client interface

### DIFF
--- a/packages/libsql-client-wasm/src/wasm.ts
+++ b/packages/libsql-client-wasm/src/wasm.ts
@@ -219,10 +219,22 @@ export class Sqlite3Client implements Client {
         );
     }
 
+    async reconnect(): Promise<void> {
+        try {
+            if (!this.closed && this.#db !== null) {
+                this.#db.close();
+            }
+        } finally {
+            this.#db = new this.#sqlite3.oo1.DB(this.#path, "c");
+            this.closed = false;
+        }
+    }
+
     close(): void {
         this.closed = true;
         if (this.#db !== null) {
             this.#db.close();
+            this.#db = null;
         }
     }
 

--- a/packages/libsql-client/src/sqlite3.ts
+++ b/packages/libsql-client/src/sqlite3.ts
@@ -222,10 +222,22 @@ export class Sqlite3Client implements Client {
         } as Replicated;
     }
 
+    async reconnect(): Promise<void> {
+        try {
+            if (!this.closed && this.#db !== null) {
+                this.#db.close();
+            }
+        } finally {
+            this.#db = new Database(this.#path, this.#options);
+            this.closed = false;
+        }
+    }
+
     close(): void {
         this.closed = true;
         if (this.#db !== null) {
             this.#db.close();
+            this.#db = null;
         }
     }
 

--- a/packages/libsql-core/src/api.ts
+++ b/packages/libsql-core/src/api.ts
@@ -240,6 +240,10 @@ export interface Client {
      */
     close(): void;
 
+    /** Reconnect after the client has been closed.
+     */
+    reconnect(): void;
+
     /** Is the client closed?
      *
      * This is set to `true` after a call to {@link close} or if the client encounters an unrecoverable


### PR DESCRIPTION
Context:

Occasionally a client can experience a `stream not found` error when turso-server is restarted with an existing ongoing stateful `stream`, that has a baton referencing a different `ConnectionManager` instance. 

There is currently no way of resetting the connection on the client side, without calling `close`. After calling `close` a new Client instance must be created because there is no way of re-opening the connection. This adds a `reconnect` method to the Client interface to allow for this.