### PR TITLE
libsql-client: Report batch statement index on error

### DIFF
--- a/packages/libsql-core/src/api.ts
+++ b/packages/libsql-core/src/api.ts
@@ -504,3 +504,21 @@ export class LibsqlError extends Error {
         this.name = "LibsqlError";
     }
 }
+
+/** Error thrown by the client during batch operations. */
+export class LibsqlBatchError extends LibsqlError {
+    /** The zero-based index of the statement that failed in the batch. */
+    statementIndex: number;
+
+    constructor(
+        message: string,
+        statementIndex: number,
+        code: string,
+        rawCode?: number,
+        cause?: Error,
+    ) {
+        super(message, code, rawCode, cause);
+        this.statementIndex = statementIndex;
+        this.name = "LibsqlBatchError";
+    }
+}


### PR DESCRIPTION
If a batch statement fails, the SQL over HTTP protocol does report back exactly what step failed. However, we also need to propagate that information to the caller.