### PR TITLE
sqlite3: keep connection handle for in-memory databases across transactions

### DIFF
--- a/packages/libsql-client/src/__tests__/client.test.ts
+++ b/packages/libsql-client/src/__tests__/client.test.ts
@@ -289,7 +289,14 @@ describe("execute()", () => {
         }),
     );
 
-    // see issue https://github.com/tursodatabase/libsql/issues/1411
+    // see issues
+    //   https://github.com/tursodatabase/libsql/issues/1411
+    //   https://github.com/tursodatabase/libsql-client-ts/issues/229
+    // Every in-memory URL form must keep schema and data alive across a
+    // client.transaction() call. An in-memory database only exists on the
+    // open connection, so for :memory: URLs the client must NOT release its
+    // handle when a transaction starts — otherwise the next client.execute()
+    // opens a fresh empty :memory: database and the table silently vanishes.
     test(
         "execute transaction against in memory database with shared cache",
         withClient(
@@ -309,7 +316,7 @@ describe("execute()", () => {
                 await c.execute("CREATE TABLE t (a)");
                 const transaction = await c.transaction();
                 transaction.close();
-                expect(() => c.execute("SELECT * FROM t")).rejects.toThrow();
+                await c.execute("SELECT * FROM t");
             },
             { url: "file::memory:?cache=private" },
         ),
@@ -321,10 +328,55 @@ describe("execute()", () => {
                 await c.execute("CREATE TABLE t (a)");
                 const transaction = await c.transaction();
                 transaction.close();
-                expect(() => c.execute("SELECT * FROM t")).rejects.toThrow();
+                await c.execute("SELECT * FROM t");
             },
             { url: ":memory:" },
         ),
+    );
+    test(
+        "in-memory database preserves schema and data across committed transaction",
+        withInMemoryClient(async (c) => {
+            await c.execute(
+                "CREATE TABLE things (id INTEGER PRIMARY KEY, name TEXT)",
+            );
+            await c.execute(
+                "INSERT INTO things (id, name) VALUES (1, 'first')",
+            );
+
+            const txn = await c.transaction("write");
+            await txn.execute(
+                "INSERT INTO things (id, name) VALUES (2, 'second')",
+            );
+            await txn.commit();
+
+            const result = await c.execute(
+                "SELECT id, name FROM things ORDER BY id",
+            );
+            expect(result.rows).toHaveLength(2);
+            expect(Array.from(result.rows[0])).toStrictEqual([1, "first"]);
+            expect(Array.from(result.rows[1])).toStrictEqual([2, "second"]);
+        }),
+    );
+    test(
+        "in-memory database rollback leaves original state intact",
+        withInMemoryClient(async (c) => {
+            await c.execute(
+                "CREATE TABLE things (id INTEGER PRIMARY KEY, name TEXT)",
+            );
+            await c.execute(
+                "INSERT INTO things (id, name) VALUES (1, 'first')",
+            );
+
+            const txn = await c.transaction("write");
+            await txn.execute(
+                "INSERT INTO things (id, name) VALUES (2, 'second')",
+            );
+            await txn.rollback();
+
+            const result = await c.execute("SELECT id, name FROM things");
+            expect(result.rows).toHaveLength(1);
+            expect(Array.from(result.rows[0])).toStrictEqual([1, "first"]);
+        }),
     );
 });
 

--- a/packages/libsql-client/src/__tests__/client.test.ts
+++ b/packages/libsql-client/src/__tests__/client.test.ts
@@ -286,7 +286,14 @@ describe("execute()", () => {
         }),
     );
 
-    // see issue https://github.com/tursodatabase/libsql/issues/1411
+    // see issues
+    //   https://github.com/tursodatabase/libsql/issues/1411
+    //   https://github.com/tursodatabase/libsql-client-ts/issues/229
+    // Every in-memory URL form must keep schema and data alive across a
+    // client.transaction() call. An in-memory database only exists on the
+    // open connection, so for :memory: URLs the client must NOT release its
+    // handle when a transaction starts — otherwise the next client.execute()
+    // opens a fresh empty :memory: database and the table silently vanishes.
     test(
         "execute transaction against in memory database with shared cache",
         withClient(
@@ -306,7 +313,7 @@ describe("execute()", () => {
                 await c.execute("CREATE TABLE t (a)");
                 const transaction = await c.transaction();
                 transaction.close();
-                expect(() => c.execute("SELECT * FROM t")).rejects.toThrow();
+                await c.execute("SELECT * FROM t");
             },
             { url: "file::memory:?cache=private" },
         ),
@@ -318,10 +325,55 @@ describe("execute()", () => {
                 await c.execute("CREATE TABLE t (a)");
                 const transaction = await c.transaction();
                 transaction.close();
-                expect(() => c.execute("SELECT * FROM t")).rejects.toThrow();
+                await c.execute("SELECT * FROM t");
             },
             { url: ":memory:" },
         ),
+    );
+    test(
+        "in-memory database preserves schema and data across committed transaction",
+        withInMemoryClient(async (c) => {
+            await c.execute(
+                "CREATE TABLE things (id INTEGER PRIMARY KEY, name TEXT)",
+            );
+            await c.execute(
+                "INSERT INTO things (id, name) VALUES (1, 'first')",
+            );
+
+            const txn = await c.transaction("write");
+            await txn.execute(
+                "INSERT INTO things (id, name) VALUES (2, 'second')",
+            );
+            await txn.commit();
+
+            const result = await c.execute(
+                "SELECT id, name FROM things ORDER BY id",
+            );
+            expect(result.rows).toHaveLength(2);
+            expect(Array.from(result.rows[0])).toStrictEqual([1, "first"]);
+            expect(Array.from(result.rows[1])).toStrictEqual([2, "second"]);
+        }),
+    );
+    test(
+        "in-memory database rollback leaves original state intact",
+        withInMemoryClient(async (c) => {
+            await c.execute(
+                "CREATE TABLE things (id INTEGER PRIMARY KEY, name TEXT)",
+            );
+            await c.execute(
+                "INSERT INTO things (id, name) VALUES (1, 'first')",
+            );
+
+            const txn = await c.transaction("write");
+            await txn.execute(
+                "INSERT INTO things (id, name) VALUES (2, 'second')",
+            );
+            await txn.rollback();
+
+            const result = await c.execute("SELECT id, name FROM things");
+            expect(result.rows).toHaveLength(1);
+            expect(Array.from(result.rows[0])).toStrictEqual([1, "first"]);
+        }),
     );
 });
 

--- a/packages/libsql-client/src/__tests__/client.test.ts
+++ b/packages/libsql-client/src/__tests__/client.test.ts
@@ -1,4 +1,7 @@
 import console from "node:console";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { expect } from "@jest/globals";
 import type { MatcherFunction } from "expect";
 
@@ -62,6 +65,29 @@ function withInMemoryClient(
         }
     };
 }
+
+function withFileClient(
+    f: (c: libsql.Client) => Promise<void>,
+): () => Promise<void> {
+    return async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), "libsql-test-"));
+        const c = createClient({ url: `file:${path.join(dir, "test.db")}` });
+        try {
+            await f(c);
+        } finally {
+            c.close();
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
+    };
+}
+
+// A client owns one connection, and an open transaction runs on it. The rules
+// below must therefore hold identically for in-memory and file-backed
+// databases - that symmetry is the point, so run each test against both.
+const localClients: Array<[string, typeof withInMemoryClient]> = [
+    ["in-memory", withInMemoryClient],
+    ["file-backed", withFileClient],
+];
 
 describe("createClient()", () => {
     test("URL scheme not supported", () => {
@@ -373,6 +399,254 @@ describe("execute()", () => {
             const result = await c.execute("SELECT id, name FROM things");
             expect(result.rows).toHaveLength(1);
             expect(Array.from(result.rows[0])).toStrictEqual([1, "first"]);
+        }),
+    );
+
+    describe.each(localClients)("%s client", (_name, withLocalClient) => {
+        // A client owns a pool of connections. Client calls borrow one for the
+        // duration of the call; a transaction borrows one for its lifetime and
+        // returns it on commit, rollback or close. Nothing is shared between an
+        // open transaction and the rest of the client - the same arrangement
+        // the hrana clients get from streams.
+        test(
+            "a bare BEGIN through client.execute does not span calls",
+            withLocalClient(async (c) => {
+                await c.execute("CREATE TABLE t (a)");
+                // the connection goes back to the pool after each call, so a
+                // transaction opened this way is rolled back, not carried over
+                await c.execute("BEGIN");
+                await c.execute("INSERT INTO t VALUES (1)");
+
+                const result = await c.execute("SELECT count(*) AS n FROM t");
+                expect(result.rows[0]["n"]).toStrictEqual(1);
+            }),
+        );
+        // Holding several transactions at once forces the pool to hand out that
+        // many distinct connections: a second BEGIN on an already-borrowed
+        // connection would fail with "cannot start a transaction within a
+        // transaction". So this asserts what the pool depends on - that every
+        // connection reaches the same database, including for `:memory:`,
+        // where that only holds because the client gives the database a name
+        // and opens it through the shared cache.
+        test(
+            "a transaction returns its connection when it commits",
+            withLocalClient(async (c) => {
+                await c.execute("CREATE TABLE t (a)");
+                // many more transactions than the pool can hold at once: this
+                // only completes if each one gives its connection back
+                for (let i = 0; i < 50; i++) {
+                    const txn = await c.transaction("write");
+                    await txn.execute(`INSERT INTO t VALUES (${i})`);
+                    await txn.commit();
+                }
+                const result = await c.execute("SELECT count(*) AS n FROM t");
+                expect(result.rows[0]["n"]).toStrictEqual(50);
+            }),
+        );
+        test(
+            "a transaction returns its connection when it rolls back or closes",
+            withLocalClient(async (c) => {
+                await c.execute("CREATE TABLE t (a)");
+                for (let i = 0; i < 25; i++) {
+                    const rolled = await c.transaction("write");
+                    await rolled.execute("INSERT INTO t VALUES (1)");
+                    await rolled.rollback();
+
+                    const closed = await c.transaction("write");
+                    await closed.execute("INSERT INTO t VALUES (2)");
+                    closed.close();
+                }
+                const result = await c.execute("SELECT count(*) AS n FROM t");
+                expect(result.rows[0]["n"]).toStrictEqual(0);
+            }),
+        );
+        test(
+            "a connection left mid-transaction is not handed on in that state",
+            withLocalClient(async (c) => {
+                await c.execute("CREATE TABLE t (a)");
+                // leaves a transaction open on the borrowed connection
+                await c.executeMultiple("BEGIN; INSERT INTO t VALUES (1);");
+
+                // the next borrower must not inherit it
+                const result = await c.execute("SELECT count(*) AS n FROM t");
+                expect(result.rows[0]["n"]).toStrictEqual(0);
+            }),
+        );
+        test(
+            "client.close() with an open transaction does not crash",
+            withLocalClient(async (c) => {
+                await c.execute("CREATE TABLE t (a)");
+                const txn = await c.transaction("write");
+
+                // closing the client closes the connection the transaction holds
+                c.close();
+
+                expect(txn.closed).toBe(true);
+                expect(() => txn.close()).not.toThrow();
+                await expect(txn.rollback()).resolves.toBeUndefined();
+                await expect(txn.commit()).rejects.toBeLibsqlError(
+                    "TRANSACTION_CLOSED",
+                );
+            }),
+        );
+    });
+
+    test(
+        "client.execute during a transaction runs outside it",
+        withFileClient(async (c) => {
+            await c.execute("CREATE TABLE u (b)");
+            const txn = await c.transaction("deferred");
+
+            // borrows a different connection, so this is not part of txn
+            await c.execute("INSERT INTO u VALUES (1)");
+            await txn.rollback();
+
+            // the client's write survived the transaction's rollback,
+            // because it was never part of that transaction
+            const result = await c.execute("SELECT count(*) AS n FROM u");
+            expect(result.rows[0]["n"]).toStrictEqual(1);
+        }),
+    );
+    test(
+        "connections held at the same time all see the same database",
+        withFileClient(async (c) => {
+            await c.execute("CREATE TABLE t (a)");
+            await c.execute("INSERT INTO t VALUES (1)");
+
+            const txns = await Promise.all(
+                [0, 1, 2, 3].map(() => c.transaction("deferred")),
+            );
+            try {
+                for (const txn of txns) {
+                    const result = await txn.execute(
+                        "SELECT count(*) AS n FROM t",
+                    );
+                    expect(result.rows[0]["n"]).toStrictEqual(1);
+                }
+            } finally {
+                await Promise.all(txns.map((txn) => txn.rollback()));
+            }
+        }),
+    );
+    test(
+        "a committed write is visible on the other pooled connections",
+        withFileClient(async (c) => {
+            await c.execute("CREATE TABLE t (a)");
+
+            // hold two connections so the write below cannot reuse either
+            const held = await Promise.all([
+                c.transaction("deferred"),
+                c.transaction("deferred"),
+            ]);
+            const txn = await c.transaction("write");
+            await txn.execute("INSERT INTO t VALUES (1)");
+            await txn.commit();
+            await Promise.all(held.map((h) => h.rollback()));
+
+            // every connection is back in the pool; all of them must see it
+            const seen = await Promise.all(
+                [0, 1, 2, 3].map(() =>
+                    c.execute("SELECT count(*) AS n FROM t"),
+                ),
+            );
+            for (const result of seen) {
+                expect(result.rows[0]["n"]).toStrictEqual(1);
+            }
+        }),
+    );
+
+    // Where the two kinds necessarily differ. A file gives a reader on another
+    // connection a clean pre-transaction snapshot. An in-memory database has
+    // no such isolation: connections reach it through the shared cache, whose
+    // table locks make a read of a table the transaction has written fail.
+    test(
+        "file-backed reads during a transaction see the pre-transaction state",
+        withFileClient(async (c) => {
+            await c.execute("CREATE TABLE t (a)");
+            await c.execute("INSERT INTO t VALUES (1)");
+            const txn = await c.transaction("write");
+            await txn.execute("INSERT INTO t VALUES (2)");
+
+            const result = await c.execute("SELECT count(*) AS n FROM t");
+            expect(result.rows[0]["n"]).toStrictEqual(1);
+
+            await txn.commit();
+            const after = await c.execute("SELECT count(*) AS n FROM t");
+            expect(after.rows[0]["n"]).toStrictEqual(2);
+        }),
+    );
+    // An in-memory database exists only on the connection that opened it, so
+    // an in-memory client has exactly one. A transaction holds it until it
+    // settles, and nothing else can be served in the meantime.
+    test(
+        "in-memory client calls during an open transaction are refused, not hung",
+        withInMemoryClient(async (c) => {
+            await c.execute("CREATE TABLE t (a)");
+            await c.execute("INSERT INTO t VALUES (1)");
+            const txn = await c.transaction("write");
+            await txn.execute("INSERT INTO t VALUES (2)");
+
+            await expect(c.execute("SELECT 1")).rejects.toBeLibsqlError(
+                "TRANSACTION_ACTIVE",
+            );
+            await expect(c.transaction("write")).rejects.toBeLibsqlError(
+                "TRANSACTION_ACTIVE",
+            );
+
+            // the caller's transaction is untouched by the refusal
+            expect(txn.closed).toBe(false);
+            await txn.commit();
+            const after = await c.execute("SELECT count(*) AS n FROM t");
+            expect(after.rows[0]["n"]).toStrictEqual(2);
+        }),
+    );
+    test(
+        "in-memory client calls still queue behind each other",
+        withInMemoryClient(async (c) => {
+            await c.execute("CREATE TABLE t (a)");
+            await c.execute("INSERT INTO t VALUES (1)");
+
+            // no transaction is involved, so these share the one connection by
+            // waiting for it rather than failing
+            const results = await Promise.all([
+                c.execute("SELECT count(*) AS n FROM t"),
+                c.execute("SELECT count(*) AS n FROM t"),
+                c.execute("SELECT count(*) AS n FROM t"),
+                c.execute("SELECT count(*) AS n FROM t"),
+            ]);
+            for (const result of results) {
+                expect(result.rows[0]["n"]).toStrictEqual(1);
+            }
+        }),
+    );
+    test(
+        "an in-memory database with a private cache survives a transaction",
+        withClient(
+            async (c) => {
+                await c.execute("CREATE TABLE t (a)");
+                await c.execute("INSERT INTO t VALUES (1)");
+                const txn = await c.transaction("write");
+                await txn.execute("INSERT INTO t VALUES (2)");
+                await txn.commit();
+
+                const result = await c.execute("SELECT count(*) AS n FROM t");
+                expect(result.rows[0]["n"]).toStrictEqual(2);
+            },
+            { url: "file::memory:?cache=private" },
+        ),
+    );
+    test(
+        "separate in-memory clients do not share a database",
+        withInMemoryClient(async (c) => {
+            await c.execute("CREATE TABLE isolated (a)");
+            const other = createClient({ url: ":memory:" });
+            try {
+                await expect(
+                    other.execute("SELECT * FROM isolated"),
+                ).rejects.toBeLibsqlError();
+            } finally {
+                other.close();
+            }
         }),
     );
 });

--- a/packages/libsql-client/src/__tests__/client.test.ts
+++ b/packages/libsql-client/src/__tests__/client.test.ts
@@ -473,6 +473,65 @@ describe("execute()", () => {
             }),
         );
         test(
+            "client.close() settles operations that are waiting for a connection",
+            withLocalClient(async (c) => {
+                await c.execute("CREATE TABLE t (a)");
+
+                // the first borrows a connection, the rest queue behind it
+                const inFlight = [
+                    c.execute("SELECT 1"),
+                    c.execute("SELECT 2"),
+                    c.execute("SELECT 3"),
+                ];
+                // stop them becoming unhandled rejections while we close
+                inFlight.forEach((p) => p.catch(() => {}));
+                c.close();
+
+                // none of these may hang: a queued waiter that is dropped
+                // rather than rejected never settles at all
+                for (const pending of inFlight) {
+                    await expect(
+                        Promise.race([
+                            pending,
+                            new Promise((_, reject) =>
+                                setTimeout(
+                                    () => reject(new Error("never settled")),
+                                    2000,
+                                ),
+                            ),
+                        ]),
+                    ).rejects.toBeLibsqlError("CLIENT_CLOSED");
+                }
+            }),
+        );
+        test(
+            "client.reconnect() settles operations that are waiting for a connection",
+            withLocalClient(async (c) => {
+                await c.execute("CREATE TABLE t (a)");
+
+                const inFlight = [c.execute("SELECT 1"), c.execute("SELECT 2")];
+                inFlight.forEach((p) => p.catch(() => {}));
+                await c.reconnect();
+
+                for (const pending of inFlight) {
+                    await expect(
+                        Promise.race([
+                            pending,
+                            new Promise((_, reject) =>
+                                setTimeout(
+                                    () => reject(new Error("never settled")),
+                                    2000,
+                                ),
+                            ),
+                        ]),
+                    ).rejects.toBeLibsqlError("CLIENT_CLOSED");
+                }
+
+                // the client is usable again afterwards
+                await expect(c.execute("SELECT 1")).resolves.toBeDefined();
+            }),
+        );
+        test(
             "client.close() with an open transaction does not crash",
             withLocalClient(async (c) => {
                 await c.execute("CREATE TABLE t (a)");

--- a/packages/libsql-client/src/sqlite3.ts
+++ b/packages/libsql-client/src/sqlite3.ts
@@ -96,7 +96,7 @@ export function _createClient(config: ExpandedConfig): Client {
         config.intMode,
     );
 
-    return new Sqlite3Client(path, options, db, config.intMode);
+    return new Sqlite3Client(path, options, db, config.intMode, isInMemory);
 }
 
 export class Sqlite3Client implements Client {
@@ -104,6 +104,7 @@ export class Sqlite3Client implements Client {
     #options: Database.Options;
     #db: Database.Database | null;
     #intMode: IntMode;
+    #isInMemory: boolean;
     closed: boolean;
     protocol: "file";
 
@@ -113,11 +114,13 @@ export class Sqlite3Client implements Client {
         options: Database.Options,
         db: Database.Database,
         intMode: IntMode,
+        isInMemory: boolean = false,
     ) {
         this.#path = path;
         this.#options = options;
         this.#db = db;
         this.#intMode = intMode;
+        this.#isInMemory = isInMemory;
         this.closed = false;
         this.protocol = "file";
     }
@@ -239,7 +242,18 @@ export class Sqlite3Client implements Client {
     async transaction(mode: TransactionMode = "write"): Promise<Transaction> {
         const db = this.#getDb();
         executeStmt(db, transactionModeToBegin(mode), this.#intMode);
-        this.#db = null; // A new connection will be lazily created on next use
+        // For file-backed databases we release the client's handle so a future
+        // `client.execute(...)` opens a second connection and runs outside the
+        // transaction. For in-memory databases the "database" only exists on
+        // the open connection, so releasing the handle would cause every
+        // subsequent query to open a brand-new empty `:memory:` database and
+        // silently lose all prior schema and data. Keep the handle shared for
+        // in-memory URLs; the transaction and the client then use the same
+        // connection, which is the only safe option for `:memory:`.
+        // See https://github.com/tursodatabase/libsql-client-ts/issues/229
+        if (!this.#isInMemory) {
+            this.#db = null;
+        }
         return new Sqlite3Transaction(db, this.#intMode);
     }
 

--- a/packages/libsql-client/src/sqlite3.ts
+++ b/packages/libsql-client/src/sqlite3.ts
@@ -97,7 +97,7 @@ export function _createClient(config: ExpandedConfig): Client {
         config.intMode,
     );
 
-    return new Sqlite3Client(path, options, db, config.intMode);
+    return new Sqlite3Client(path, options, db, config.intMode, isInMemory);
 }
 
 export class Sqlite3Client implements Client {
@@ -105,6 +105,7 @@ export class Sqlite3Client implements Client {
     #options: Database.Options;
     #db: Database.Database | null;
     #intMode: IntMode;
+    #isInMemory: boolean;
     closed: boolean;
     protocol: "file";
 
@@ -114,11 +115,13 @@ export class Sqlite3Client implements Client {
         options: Database.Options,
         db: Database.Database,
         intMode: IntMode,
+        isInMemory: boolean = false,
     ) {
         this.#path = path;
         this.#options = options;
         this.#db = db;
         this.#intMode = intMode;
+        this.#isInMemory = isInMemory;
         this.closed = false;
         this.protocol = "file";
     }
@@ -240,7 +243,18 @@ export class Sqlite3Client implements Client {
     async transaction(mode: TransactionMode = "write"): Promise<Transaction> {
         const db = this.#getDb();
         executeStmt(db, transactionModeToBegin(mode), this.#intMode);
-        this.#db = null; // A new connection will be lazily created on next use
+        // For file-backed databases we release the client's handle so a future
+        // `client.execute(...)` opens a second connection and runs outside the
+        // transaction. For in-memory databases the "database" only exists on
+        // the open connection, so releasing the handle would cause every
+        // subsequent query to open a brand-new empty `:memory:` database and
+        // silently lose all prior schema and data. Keep the handle shared for
+        // in-memory URLs; the transaction and the client then use the same
+        // connection, which is the only safe option for `:memory:`.
+        // See https://github.com/tursodatabase/libsql-client-ts/issues/229
+        if (!this.#isInMemory) {
+            this.#db = null;
+        }
         return new Sqlite3Transaction(db, this.#intMode);
     }
 

--- a/packages/libsql-client/src/sqlite3.ts
+++ b/packages/libsql-client/src/sqlite3.ts
@@ -132,7 +132,10 @@ export class ConnectionPool {
     #borrowed: Set<Database.Database>;
     // the subset of `#borrowed` held by an open transaction
     #heldByTransaction: Set<Database.Database>;
-    #waiters: Array<(db: Database.Database) => void>;
+    #waiters: Array<{
+        resolve: (db: Database.Database) => void;
+        reject: (e: unknown) => void;
+    }>;
     #closed: boolean;
 
     constructor(
@@ -173,12 +176,15 @@ export class ConnectionPool {
                     ),
                 );
             }
-            return new Promise((resolve) =>
-                this.#waiters.push((db) => {
-                    if (forTransaction) {
-                        this.#heldByTransaction.add(db);
-                    }
-                    resolve(db);
+            return new Promise((resolve, reject) =>
+                this.#waiters.push({
+                    resolve: (db) => {
+                        if (forTransaction) {
+                            this.#heldByTransaction.add(db);
+                        }
+                        resolve(db);
+                    },
+                    reject,
                 }),
             );
         }
@@ -228,7 +234,7 @@ export class ConnectionPool {
         const waiter = this.#waiters.shift();
         if (waiter !== undefined) {
             this.#borrowed.add(db);
-            waiter(db);
+            waiter.resolve(db);
         } else {
             this.#idle.push(db);
         }
@@ -245,8 +251,16 @@ export class ConnectionPool {
         }
         this.#borrowed.clear();
         this.#heldByTransaction.clear();
-        // anything still waiting will never be served; let it fail loudly
+
+        // Anything still queued will never be served now. Reject it: dropping
+        // the callbacks would leave those operations pending forever.
+        const waiters = this.#waiters;
         this.#waiters = [];
+        for (const waiter of waiters) {
+            waiter.reject(
+                new LibsqlError("The client is closed", "CLIENT_CLOSED"),
+            );
+        }
     }
 
     reopen(): void {
@@ -310,6 +324,7 @@ export class Sqlite3Client implements Client {
         this.#checkNotClosed();
         const db = await this.#pool.acquire();
         try {
+            this.#checkUsable(db);
             return executeStmt(db, stmt, this.#intMode);
         } finally {
             this.#pool.release(db);
@@ -323,6 +338,7 @@ export class Sqlite3Client implements Client {
         this.#checkNotClosed();
         const db = await this.#pool.acquire();
         try {
+            this.#checkUsable(db);
             executeStmt(db, transactionModeToBegin(mode), this.#intMode);
             const resultSets = [];
             for (let i = 0; i < stmts.length; i++) {
@@ -370,6 +386,7 @@ export class Sqlite3Client implements Client {
         this.#checkNotClosed();
         const db = await this.#pool.acquire();
         try {
+            this.#checkUsable(db);
             executeStmt(db, "PRAGMA foreign_keys=off", this.#intMode);
             executeStmt(db, transactionModeToBegin("deferred"), this.#intMode);
             const resultSets = [];
@@ -415,6 +432,7 @@ export class Sqlite3Client implements Client {
         this.#checkNotClosed();
         const db = await this.#pool.acquire(true);
         try {
+            this.#checkUsable(db);
             executeStmt(db, transactionModeToBegin(mode), this.#intMode);
         } catch (e) {
             this.#pool.release(db);
@@ -431,6 +449,7 @@ export class Sqlite3Client implements Client {
         this.#checkNotClosed();
         const db = await this.#pool.acquire();
         try {
+            this.#checkUsable(db);
             return executeMultiple(db, sql);
         } finally {
             // `release` rolls back a transaction `sql` left open
@@ -442,6 +461,7 @@ export class Sqlite3Client implements Client {
         this.#checkNotClosed();
         const db = await this.#pool.acquire();
         try {
+            this.#checkUsable(db);
             const rep = await db.sync();
             return {
                 frames_synced: rep.frames_synced,
@@ -465,6 +485,20 @@ export class Sqlite3Client implements Client {
     #checkNotClosed(): void {
         if (this.closed) {
             throw new LibsqlError("The client is closed", "CLIENT_CLOSED");
+        }
+    }
+
+    // `close()` and `reconnect()` are synchronous and can land between a
+    // borrow and the work it was borrowed for, closing the connection under an
+    // operation that is already holding one. Without this the operation
+    // reaches libsql with a closed handle and fails with a raw TypeError.
+    #checkUsable(db: Database.Database): void {
+        this.#checkNotClosed();
+        if (!db.open) {
+            throw new LibsqlError(
+                "The connection was closed while this operation was in flight",
+                "CLIENT_CLOSED",
+            );
         }
     }
 }

--- a/packages/libsql-client/src/sqlite3.ts
+++ b/packages/libsql-client/src/sqlite3.ts
@@ -78,6 +78,13 @@ export function _createClient(config: ExpandedConfig): Client {
         path = `${config.scheme}:${config.path}`;
     }
 
+    // An in-memory database exists only on the connection that opened it, so a
+    // second connection would be a second, empty database rather than another
+    // way into the same one. Each connection to an embedded replica carries
+    // its own sync state. Both are therefore single-connection databases.
+    const maxConnections =
+        isInMemory || config.syncUrl ? 1 : Math.max(1, config.concurrency);
+
     const options = {
         authToken: config.authToken,
         encryptionKey: config.encryptionKey,
@@ -89,39 +96,198 @@ export function _createClient(config: ExpandedConfig): Client {
         timeout: config.timeout,
     };
 
-    const db = new Database(path, options);
+    const pool = new ConnectionPool(path, options, maxConnections);
 
-    executeStmt(
-        db,
-        "SELECT 1 AS checkThatTheDatabaseCanBeOpened",
-        config.intMode,
-    );
+    // fail fast if the database cannot be opened at all
+    const db = pool.acquireSync();
+    try {
+        executeStmt(
+            db,
+            "SELECT 1 AS checkThatTheDatabaseCanBeOpened",
+            config.intMode,
+        );
+    } catch (e) {
+        pool.close();
+        throw e;
+    }
+    pool.release(db);
 
-    return new Sqlite3Client(path, options, db, config.intMode, isInMemory);
+    return new Sqlite3Client(pool, config.intMode);
+}
+
+/**
+ * A client owns a small pool of connections to one database, in the same way
+ * that a remote client owns a set of hrana streams: every client operation
+ * borrows one for the duration of the call, and a transaction borrows one for
+ * its lifetime and gives it back on commit, rollback or close. Nothing is
+ * shared between an open transaction and the rest of the client.
+ *
+ * @private
+ */
+export class ConnectionPool {
+    #path: string;
+    #options: Database.Options;
+    #maxConnections: number;
+    #idle: Array<Database.Database>;
+    #borrowed: Set<Database.Database>;
+    // the subset of `#borrowed` held by an open transaction
+    #heldByTransaction: Set<Database.Database>;
+    #waiters: Array<(db: Database.Database) => void>;
+    #closed: boolean;
+
+    constructor(
+        path: string,
+        options: Database.Options,
+        maxConnections: number,
+    ) {
+        this.#path = path;
+        this.#options = options;
+        this.#maxConnections = maxConnections;
+        this.#idle = [];
+        this.#borrowed = new Set();
+        this.#heldByTransaction = new Set();
+        this.#waiters = [];
+        this.#closed = false;
+    }
+
+    // Borrows a connection, opening one if the pool is below its limit and
+    // waiting for a release if it is not.
+    //
+    // Every borrow but a transaction's is a short synchronous call that
+    // returns the connection before the caller sees it again, so waiting for
+    // one is safe. A transaction holds its connection until the caller commits
+    // or rolls back, so if transactions hold every connection there is nothing
+    // to wait for - the caller has to act first. Say so instead of hanging.
+    acquire(forTransaction: boolean = false): Promise<Database.Database> {
+        if (!this.#closed && this.#atLimit()) {
+            if (this.#heldByTransaction.size >= this.#maxConnections) {
+                return Promise.reject(
+                    new LibsqlError(
+                        this.#maxConnections === 1
+                            ? "This client has a single connection, which an open transaction is holding. " +
+                              "In-memory databases and embedded replicas cannot have more than one. " +
+                              "Commit or roll back the transaction before using the client again."
+                            : `All ${this.#maxConnections} of this client's connections are held by open transactions. ` +
+                              "Commit or roll back one before using the client again, or raise `concurrency`.",
+                        "TRANSACTION_ACTIVE",
+                    ),
+                );
+            }
+            return new Promise((resolve) =>
+                this.#waiters.push((db) => {
+                    if (forTransaction) {
+                        this.#heldByTransaction.add(db);
+                    }
+                    resolve(db);
+                }),
+            );
+        }
+        try {
+            return Promise.resolve(this.acquireSync(forTransaction));
+        } catch (e) {
+            return Promise.reject(e);
+        }
+    }
+
+    // Borrows a connection without waiting. Only valid when the pool cannot be
+    // at its limit yet, which is why it is used for the initial probe.
+    acquireSync(forTransaction: boolean = false): Database.Database {
+        this.#checkNotClosed();
+        const idle = this.#idle.pop();
+        const db = idle ?? new Database(this.#path, this.#options);
+        this.#borrowed.add(db);
+        if (forTransaction) {
+            this.#heldByTransaction.add(db);
+        }
+        return db;
+    }
+
+    // Returns a borrowed connection to the pool, handing it straight to a
+    // waiter if there is one.
+    release(db: Database.Database): void {
+        this.#borrowed.delete(db);
+        this.#heldByTransaction.delete(db);
+
+        // A connection must never go back into the pool mid-transaction, or
+        // the next borrower would silently inherit it.
+        if (db.open && db.inTransaction) {
+            try {
+                db.prepare("ROLLBACK").run();
+            } catch {
+                // the connection is unusable; drop it rather than reuse it
+                closeQuietly(db);
+                return;
+            }
+        }
+
+        if (this.#closed || !db.open) {
+            closeQuietly(db);
+            return;
+        }
+
+        const waiter = this.#waiters.shift();
+        if (waiter !== undefined) {
+            this.#borrowed.add(db);
+            waiter(db);
+        } else {
+            this.#idle.push(db);
+        }
+    }
+
+    close(): void {
+        this.#closed = true;
+        for (const db of this.#idle) {
+            closeQuietly(db);
+        }
+        this.#idle = [];
+        for (const db of this.#borrowed) {
+            closeQuietly(db);
+        }
+        this.#borrowed.clear();
+        this.#heldByTransaction.clear();
+        // anything still waiting will never be served; let it fail loudly
+        this.#waiters = [];
+    }
+
+    reopen(): void {
+        this.close();
+        this.#closed = false;
+    }
+
+    #atLimit(): boolean {
+        return (
+            this.#idle.length === 0 &&
+            this.#borrowed.size >= this.#maxConnections
+        );
+    }
+
+    #checkNotClosed(): void {
+        if (this.#closed) {
+            throw new LibsqlError("The client is closed", "CLIENT_CLOSED");
+        }
+    }
+}
+
+function closeQuietly(db: Database.Database): void {
+    try {
+        if (db.open) {
+            db.close();
+        }
+    } catch {
+        // nothing useful to do while tearing down
+    }
 }
 
 export class Sqlite3Client implements Client {
-    #path: string;
-    #options: Database.Options;
-    #db: Database.Database | null;
+    #pool: ConnectionPool;
     #intMode: IntMode;
-    #isInMemory: boolean;
     closed: boolean;
     protocol: "file";
 
     /** @private */
-    constructor(
-        path: string,
-        options: Database.Options,
-        db: Database.Database,
-        intMode: IntMode,
-        isInMemory: boolean = false,
-    ) {
-        this.#path = path;
-        this.#options = options;
-        this.#db = db;
+    constructor(pool: ConnectionPool, intMode: IntMode) {
+        this.#pool = pool;
         this.#intMode = intMode;
-        this.#isInMemory = isInMemory;
         this.closed = false;
         this.protocol = "file";
     }
@@ -142,7 +308,12 @@ export class Sqlite3Client implements Client {
         }
 
         this.#checkNotClosed();
-        return executeStmt(this.#getDb(), stmt, this.#intMode);
+        const db = await this.#pool.acquire();
+        try {
+            return executeStmt(db, stmt, this.#intMode);
+        } finally {
+            this.#pool.release(db);
+        }
     }
 
     async batch(
@@ -150,7 +321,7 @@ export class Sqlite3Client implements Client {
         mode: TransactionMode = "deferred",
     ): Promise<Array<ResultSet>> {
         this.#checkNotClosed();
-        const db = this.#getDb();
+        const db = await this.#pool.acquire();
         try {
             executeStmt(db, transactionModeToBegin(mode), this.#intMode);
             const resultSets = [];
@@ -190,15 +361,14 @@ export class Sqlite3Client implements Client {
             executeStmt(db, "COMMIT", this.#intMode);
             return resultSets;
         } finally {
-            if (db.inTransaction) {
-                executeStmt(db, "ROLLBACK", this.#intMode);
-            }
+            // `release` rolls back anything still open before reuse
+            this.#pool.release(db);
         }
     }
 
     async migrate(stmts: Array<InStatement>): Promise<Array<ResultSet>> {
         this.#checkNotClosed();
-        const db = this.#getDb();
+        const db = await this.#pool.acquire();
         try {
             executeStmt(db, "PRAGMA foreign_keys=off", this.#intMode);
             executeStmt(db, transactionModeToBegin("deferred"), this.#intMode);
@@ -237,65 +407,59 @@ export class Sqlite3Client implements Client {
                 executeStmt(db, "ROLLBACK", this.#intMode);
             }
             executeStmt(db, "PRAGMA foreign_keys=on", this.#intMode);
+            this.#pool.release(db);
         }
     }
 
     async transaction(mode: TransactionMode = "write"): Promise<Transaction> {
-        const db = this.#getDb();
-        executeStmt(db, transactionModeToBegin(mode), this.#intMode);
-        // For file-backed databases we release the client's handle so a future
-        // `client.execute(...)` opens a second connection and runs outside the
-        // transaction. For in-memory databases the "database" only exists on
-        // the open connection, so releasing the handle would cause every
-        // subsequent query to open a brand-new empty `:memory:` database and
-        // silently lose all prior schema and data. Keep the handle shared for
-        // in-memory URLs; the transaction and the client then use the same
-        // connection, which is the only safe option for `:memory:`.
-        // See https://github.com/tursodatabase/libsql-client-ts/issues/229
-        if (!this.#isInMemory) {
-            this.#db = null;
+        this.#checkNotClosed();
+        const db = await this.#pool.acquire(true);
+        try {
+            executeStmt(db, transactionModeToBegin(mode), this.#intMode);
+        } catch (e) {
+            this.#pool.release(db);
+            throw e;
         }
-        return new Sqlite3Transaction(db, this.#intMode);
+        // The transaction owns this connection until it settles, exactly as an
+        // `HttpTransaction` owns its stream.
+        return new Sqlite3Transaction(db, this.#intMode, (used) =>
+            this.#pool.release(used),
+        );
     }
 
     async executeMultiple(sql: string): Promise<void> {
         this.#checkNotClosed();
-        const db = this.#getDb();
+        const db = await this.#pool.acquire();
         try {
             return executeMultiple(db, sql);
         } finally {
-            if (db.inTransaction) {
-                executeStmt(db, "ROLLBACK", this.#intMode);
-            }
+            // `release` rolls back a transaction `sql` left open
+            this.#pool.release(db);
         }
     }
 
     async sync(): Promise<Replicated> {
         this.#checkNotClosed();
-        const rep = await this.#getDb().sync();
-        return {
-            frames_synced: rep.frames_synced,
-            frame_no: rep.frame_no,
-        } as Replicated;
+        const db = await this.#pool.acquire();
+        try {
+            const rep = await db.sync();
+            return {
+                frames_synced: rep.frames_synced,
+                frame_no: rep.frame_no,
+            } as Replicated;
+        } finally {
+            this.#pool.release(db);
+        }
     }
 
     async reconnect(): Promise<void> {
-        try {
-            if (!this.closed && this.#db !== null) {
-                this.#db.close();
-            }
-        } finally {
-            this.#db = new Database(this.#path, this.#options);
-            this.closed = false;
-        }
+        this.#pool.reopen();
+        this.closed = false;
     }
 
     close(): void {
         this.closed = true;
-        if (this.#db !== null) {
-            this.#db.close();
-            this.#db = null;
-        }
+        this.#pool.close();
     }
 
     #checkNotClosed(): void {
@@ -303,24 +467,39 @@ export class Sqlite3Client implements Client {
             throw new LibsqlError("The client is closed", "CLIENT_CLOSED");
         }
     }
-
-    // Lazily creates the database connection and returns it
-    #getDb(): Database.Database {
-        if (this.#db === null) {
-            this.#db = new Database(this.#path, this.#options);
-        }
-        return this.#db;
-    }
 }
 
 export class Sqlite3Transaction implements Transaction {
-    #database: Database.Database;
+    // null once the connection has been returned to the pool
+    #database: Database.Database | null;
     #intMode: IntMode;
+    #release: (db: Database.Database) => void;
 
     /** @private */
-    constructor(database: Database.Database, intMode: IntMode) {
+    constructor(
+        database: Database.Database,
+        intMode: IntMode,
+        release: (db: Database.Database) => void,
+    ) {
         this.#database = database;
         this.#intMode = intMode;
+        this.#release = release;
+    }
+
+    // Returns the connection to the pool. Idempotent, so every exit path can
+    // call it without checking whether another already did.
+    #settle(): void {
+        const db = this.#database;
+        if (db === null) {
+            return;
+        }
+        this.#database = null;
+        this.#release(db);
+    }
+
+    #getDatabase(): Database.Database {
+        this.#checkNotClosed();
+        return this.#database!;
     }
 
     async execute(stmt: InStatement): Promise<ResultSet>;
@@ -341,8 +520,7 @@ export class Sqlite3Transaction implements Transaction {
             stmt = stmtOrSql;
         }
 
-        this.#checkNotClosed();
-        return executeStmt(this.#database, stmt, this.#intMode);
+        return executeStmt(this.#getDatabase(), stmt, this.#intMode);
     }
 
     async batch(
@@ -351,14 +529,12 @@ export class Sqlite3Transaction implements Transaction {
         const resultSets = [];
         for (let i = 0; i < stmts.length; i++) {
             try {
-                this.#checkNotClosed();
+                const db = this.#getDatabase();
                 const stmt = stmts[i];
                 const normalizedStmt: InStatement = Array.isArray(stmt)
                     ? { sql: stmt[0], args: stmt[1] || [] }
                     : stmt;
-                resultSets.push(
-                    executeStmt(this.#database, normalizedStmt, this.#intMode),
-                );
+                resultSets.push(executeStmt(db, normalizedStmt, this.#intMode));
             } catch (e) {
                 if (e instanceof LibsqlBatchError) {
                     throw e;
@@ -380,31 +556,53 @@ export class Sqlite3Transaction implements Transaction {
     }
 
     async executeMultiple(sql: string): Promise<void> {
-        this.#checkNotClosed();
-        return executeMultiple(this.#database, sql);
+        return executeMultiple(this.#getDatabase(), sql);
     }
 
     async rollback(): Promise<void> {
-        if (!this.#database.open) {
+        const db = this.#database;
+        if (db === null || !db.open) {
+            this.#settle();
             return;
         }
-        this.#checkNotClosed();
-        executeStmt(this.#database, "ROLLBACK", this.#intMode);
+        try {
+            this.#checkNotClosed();
+            executeStmt(db, "ROLLBACK", this.#intMode);
+        } finally {
+            this.#settle();
+        }
     }
 
     async commit(): Promise<void> {
-        this.#checkNotClosed();
-        executeStmt(this.#database, "COMMIT", this.#intMode);
+        try {
+            executeStmt(this.#getDatabase(), "COMMIT", this.#intMode);
+        } finally {
+            this.#settle();
+        }
     }
 
     close(): void {
-        if (this.#database.inTransaction) {
-            executeStmt(this.#database, "ROLLBACK", this.#intMode);
+        const db = this.#database;
+        if (db === null) {
+            return;
+        }
+        try {
+            // `client.close()` may have closed this connection already, and
+            // reading `inTransaction` on a closed database aborts the process.
+            if (db.open && db.inTransaction) {
+                executeStmt(db, "ROLLBACK", this.#intMode);
+            }
+        } finally {
+            this.#settle();
         }
     }
 
     get closed(): boolean {
-        return !this.#database.inTransaction;
+        const db = this.#database;
+        if (db === null || !db.open) {
+            return true;
+        }
+        return !db.inTransaction;
     }
 
     #checkNotClosed(): void {


### PR DESCRIPTION
## Summary

Fix silent data loss when calling `client.transaction()` against an in-memory URL (`:memory:`, `file::memory:`, `file::memory:?cache=private`). After the transaction starts, subsequent `client.execute(...)` calls silently lose all schema and data because the client opens a brand-new, empty in-memory database.

Fixes #229. Fixes #140.

## Repro (broken on `main`)

```ts
import { createClient } from "@libsql/client";

const client = createClient({ url: ":memory:" });
await client.execute("CREATE TABLE t (id INTEGER, name TEXT)");
await client.execute("INSERT INTO t VALUES (1, 'a')");

const tx = await client.transaction("write");
await tx.execute("INSERT INTO t VALUES (2, 'b')");
await tx.commit();

await client.execute("SELECT * FROM t");
// LibsqlError: SQLITE_ERROR: no such table: t
```

Confirmed against `@libsql/client@0.17.2` and the current `main` branch.

## Root cause

In `packages/libsql-client/src/sqlite3.ts`, `Sqlite3Client.transaction()` unconditionally sets `this.#db = null` after starting the `BEGIN`, so the next call to `#getDb()` opens a **new** `Database`. For file-backed databases this is fine — reopening the file gives you the same data. For in-memory URLs the "database" only exists on the open connection; opening a second connection at `:memory:` gives you a **fresh, empty** database. Everything from the original connection becomes unreachable.

PR #220 introduced `file::memory:?cache=shared` as a workaround, but the documented `:memory:` URL remains broken on `main`.

## Fix

Adopt the model the `http` and `ws` clients already use.

There, every client call does `openStream()` → work → `closeGracefully()`, and `transaction()` hands a stream to the transaction, which closes it on commit, rollback and close alike. Nothing is shared between an open transaction and the rest of the client, and no resource outlives the call that borrowed it.

`Sqlite3Client` now owns a `ConnectionPool`, sized by `config.concurrency` — already computed in `expandConfig`, already used by the remote clients, and until now ignored here. Client calls borrow a connection and return it in a `finally`; a transaction borrows one and returns it when it settles. A connection is rolled back before it goes back into the pool, so a borrower can never inherit someone else's transaction.

```diff
 async transaction(mode: TransactionMode = "write"): Promise<Transaction> {
-    const db = this.#getDb();
+    this.#checkNotClosed();
+    const db = await this.#pool.acquire(true);
     executeStmt(db, transactionModeToBegin(mode), this.#intMode);
-    this.#db = null; // A new connection will be lazily created on next use
-    return new Sqlite3Transaction(db, this.#intMode);
+    return new Sqlite3Transaction(db, this.#intMode, (used) =>
+        this.#pool.release(used),
+    );
 }
```

This **removes** special cases rather than adding them: no `#db = null`, no `#getDb()`, no `isInMemory` flag on the client, and no rewriting of the URL the caller asked for.

### Why not just keep the handle for `:memory:`

The first commit does exactly that, and it fixes the reported bug. But `this.#db = null` is not only wrong for in-memory — `Sqlite3Transaction` never closes the connection it was handed and the client has already dropped the reference, so **every transaction against a file leaks one**:

```
open fds after 50 committed transactions
  before: 50
  after:   1
```

Keeping the handle for `:memory:` alone leaves that leak in place and puts the two database kinds on different models.

### Single-connection databases

An in-memory database exists only on the connection that opened it, so a second connection would be a second, empty database rather than another way into the same one. An in-memory client therefore has a pool of exactly one. Embedded replicas likewise, as each connection carries its own sync state.

A single connection cannot serve a client call while a transaction holds it, and waiting would hang — only the caller can end that transaction. So the pool tracks which borrows are transactions and refuses such a call immediately:

```
LibsqlError: TRANSACTION_ACTIVE: This client has a single connection, which an
open transaction is holding. In-memory databases and embedded replicas cannot
have more than one. Commit or roll back the transaction before using the
client again.
```

Every other borrow is a short synchronous call that returns the connection before the caller regains control, so those still queue — `Promise.all([...reads])` against `:memory:` keeps working.

## Behaviour

Measured, during an open write transaction:

| | `:memory:` | file |
|---|---|---|
| read an untouched table | `TRANSACTION_ACTIVE` | ok |
| read the written table | `TRANSACTION_ACTIVE` | ok — pre-transaction snapshot |
| write, batch, second transaction | `TRANSACTION_ACTIVE` | `SQLITE_BUSY` |
| `executeMultiple` | `TRANSACTION_ACTIVE` | ok |

File-backed matches the hrana clients: concurrent isolated reads, serialized writers. An in-memory client refuses overlapping work rather than pretending to a concurrency the database does not have.

**Changed behaviour to note in the release notes:** `client.execute(...)` during an open transaction no longer joins that transaction. For files it runs on another connection, as it did before. For `:memory:` it is refused, where previously it silently ran against a throwaway empty database.

## Tests

The tests run against an in-memory **and** a file-backed client from one table (`describe.each`); both helpers ignore `$URL`, so they run in every CI configuration. Cases that need a second connection are targeted at file-backed, since an in-memory client has only one.

Both kinds:
- client work during a transaction survives that transaction's rollback
- 50 sequential transactions complete — only possible if each returns its connection
- a connection left mid-transaction is not handed on in that state
- a bare `BEGIN` through `client.execute` does not span calls
- `client.close()` with an open transaction does not crash
- `client.close()` and `client.reconnect()` settle operations that are waiting for a connection, rather than leaving them pending forever

File-backed:
- `client.execute` during a transaction runs outside it
- connections held at the same time all see the same database
- a committed write is visible on the other pooled connections
- a read during a transaction sees the pre-transaction state

In-memory:
- client calls during an open transaction are refused, not hung, and the caller's transaction is untouched by the refusal
- client calls with no transaction involved still queue behind each other
- `file::memory:?cache=private` survives a transaction
- separate in-memory clients do not share a database

## Verification

Rebased onto `main` at 0.17.4.

```
npm run typecheck                            # passed
npm run build                                # passed
prettier --check                             # clean
URL=":memory:"         npx jest --runInBand  # 199 passed, 9 skipped
URL="file:/tmp/x.db"   npx jest --runInBand  # 197 passed, 11 skipped
```

Skipped tests need the Python hrana server.

## Notes

- A pool buys no throughput here — the bindings are synchronous, so four concurrent queries against a file take 4× one query (`345ms` → `1354ms`). Connections exist for isolation, not parallelism.
- Local databases are not in WAL mode (`journal_mode` is `delete`), which is why a file-backed *write* blocks even against a deferred read transaction. Changing that is its own PR.

## Follow-ups (not in this PR)

- `packages/libsql-client-wasm/src/wasm.ts:199` has the identical `this.#db = null` line and the identical leak.
- `reconnect()` on an in-memory database still opens a fresh connection.
- Running the whole suite with `URL="file::memory:?cache=shared"` fails on `table t already exists`, because that database is process-global and tests collide. Pre-existing on `main`; not a CI configuration.

