### PR TITLE
Deprecate sync() across all client implementations

### DIFF
--- a/packages/libsql-client-wasm/src/wasm.ts
+++ b/packages/libsql-client-wasm/src/wasm.ts
@@ -212,6 +212,7 @@ export class Sqlite3Client implements Client {
         }
     }
 
+    /** @deprecated sync() is deprecated and will be removed in a future release. Use `@tursodatabase/sync` instead. Learn more: https://tur.so/newsync */
     async sync(): Promise<Replicated> {
         throw new LibsqlError(
             "sync not supported in wasm mode",

--- a/packages/libsql-client/src/http.ts
+++ b/packages/libsql-client/src/http.ts
@@ -274,6 +274,7 @@ export class HttpClient implements Client {
         });
     }
 
+    /** @deprecated sync() is deprecated and will be removed in a future release. Use `@tursodatabase/sync` instead. Learn more: https://tur.so/newsync */
     sync(): Promise<Replicated> {
         throw new LibsqlError(
             "sync not supported in http mode",

--- a/packages/libsql-client/src/sqlite3.ts
+++ b/packages/libsql-client/src/sqlite3.ts
@@ -26,6 +26,8 @@ import {
 
 export * from "@libsql/core/api";
 
+let _syncDeprecationWarned = false;
+
 export function createClient(config: Config): Client {
     return _createClient(expandConfig(config, true));
 }
@@ -255,7 +257,12 @@ export class Sqlite3Client implements Client {
         }
     }
 
+    /** @deprecated sync() is deprecated and will be removed in a future release. Use `@tursodatabase/sync` instead. Learn more: https://tur.so/newsync */
     async sync(): Promise<Replicated> {
+        if (!_syncDeprecationWarned) {
+            console.warn("libSQL: sync() is deprecated and will be removed in a future release. Use `@tursodatabase/sync` instead. Learn more: https://tur.so/newsync");
+            _syncDeprecationWarned = true;
+        }
         this.#checkNotClosed();
         const rep = await this.#getDb().sync();
         return {

--- a/packages/libsql-client/src/ws.ts
+++ b/packages/libsql-client/src/ws.ts
@@ -295,6 +295,7 @@ export class WsClient implements Client {
         });
     }
 
+    /** @deprecated sync() is deprecated and will be removed in a future release. Use `@tursodatabase/sync` instead. Learn more: https://tur.so/newsync */
     sync(): Promise<Replicated> {
         throw new LibsqlError(
             "sync not supported in ws mode",

--- a/packages/libsql-core/src/api.ts
+++ b/packages/libsql-core/src/api.ts
@@ -234,6 +234,7 @@ export interface Client {
      */
     executeMultiple(sql: string): Promise<void>;
 
+    /** @deprecated sync() is deprecated and will be removed in a future release. Use `@tursodatabase/sync` instead. Learn more: https://tur.so/newsync */
     sync(): Promise<Replicated>;
 
     /** Close the client and release resources.


### PR DESCRIPTION
Add @deprecated JSDoc annotations to the Client interface and all implementations (sqlite3, http, ws, wasm). The sqlite3 implementation also emits a console.warn() at runtime. Users are directed to `@tursodatabase/sync` as a replacement. Learn more: https://tur.so/newsync