### PR TITLE
Make ResultSet generic for typed row access

### DIFF
--- a/packages/libsql-client/src/hrana.ts
+++ b/packages/libsql-client/src/hrana.ts
@@ -2,6 +2,7 @@ import * as hrana from "@libsql/hrana-client";
 import type {
     InStatement,
     ResultSet,
+    Row,
     Transaction,
     TransactionMode,
     InArgs,
@@ -32,11 +33,13 @@ export abstract class HranaTransaction implements Transaction {
     abstract close(): void;
     abstract get closed(): boolean;
 
-    execute(stmt: InStatement): Promise<ResultSet> {
-        return this.batch([stmt]).then((results) => results[0]);
+    execute<T extends Row = Row>(stmt: InStatement): Promise<ResultSet<T>> {
+        return this.batch<T>([stmt]).then((results) => results[0]);
     }
 
-    async batch(stmts: Array<InStatement>): Promise<Array<ResultSet>> {
+    async batch<T extends Row = Row>(
+        stmts: Array<InStatement>,
+    ): Promise<Array<ResultSet<T>>> {
         const stream = this._getStream();
         if (stream.closed) {
             throw new LibsqlError(
@@ -167,7 +170,7 @@ export abstract class HranaTransaction implements Transaction {
                     throw mappedError;
                 }
             }
-            return resultSets;
+            return resultSets as Array<ResultSet<T>>;
         } catch (e) {
             throw mapHranaError(e);
         }

--- a/packages/libsql-client/src/http.ts
+++ b/packages/libsql-client/src/http.ts
@@ -4,6 +4,7 @@ import type { Config, Client } from "@libsql/core/api";
 import type {
     InStatement,
     ResultSet,
+    Row,
     Transaction,
     IntMode,
     InArgs,
@@ -114,10 +115,10 @@ export class HttpClient implements Client {
         return this.#promiseLimitFunction(fn);
     }
 
-    async execute(
+    async execute<T extends Row = Row>(
         stmtOrSql: InStatement | string,
         args?: InArgs,
-    ): Promise<ResultSet> {
+    ): Promise<ResultSet<T>> {
         let stmt: InStatement;
 
         if (typeof stmtOrSql === "string") {
@@ -129,7 +130,7 @@ export class HttpClient implements Client {
             stmt = stmtOrSql;
         }
 
-        return this.limit<ResultSet>(async () => {
+        return this.limit<ResultSet<T>>(async () => {
             try {
                 const hranaStmt = stmtToHrana(stmt);
 
@@ -145,18 +146,18 @@ export class HttpClient implements Client {
 
                 const rowsResult = await rowsPromise;
 
-                return resultSetFromHrana(rowsResult);
+                return resultSetFromHrana(rowsResult) as ResultSet<T>;
             } catch (e) {
                 throw mapHranaError(e);
             }
         });
     }
 
-    async batch(
+    async batch<T extends Row = Row>(
         stmts: Array<InStatement | [string, InArgs?]>,
         mode: TransactionMode = "deferred",
-    ): Promise<Array<ResultSet>> {
-        return this.limit<Array<ResultSet>>(async () => {
+    ): Promise<Array<ResultSet<T>>> {
+        return this.limit<Array<ResultSet<T>>>(async () => {
             try {
                 const normalizedStmts = stmts.map((stmt) => {
                     if (Array.isArray(stmt)) {
@@ -198,7 +199,7 @@ export class HttpClient implements Client {
 
                 const results = await resultsPromise;
 
-                return results;
+                return results as Array<ResultSet<T>>;
             } catch (e) {
                 throw mapHranaError(e);
             }

--- a/packages/libsql-client/src/sqlite3.ts
+++ b/packages/libsql-client/src/sqlite3.ts
@@ -122,10 +122,10 @@ export class Sqlite3Client implements Client {
         this.protocol = "file";
     }
 
-    async execute(
+    async execute<T extends Row = Row>(
         stmtOrSql: InStatement | string,
         args?: InArgs,
-    ): Promise<ResultSet> {
+    ): Promise<ResultSet<T>> {
         let stmt: InStatement;
 
         if (typeof stmtOrSql === "string") {
@@ -138,13 +138,13 @@ export class Sqlite3Client implements Client {
         }
 
         this.#checkNotClosed();
-        return executeStmt(this.#getDb(), stmt, this.#intMode);
+        return executeStmt(this.#getDb(), stmt, this.#intMode) as ResultSet<T>;
     }
 
-    async batch(
+    async batch<T extends Row = Row>(
         stmts: Array<InStatement | [string, InArgs?]>,
         mode: TransactionMode = "deferred",
-    ): Promise<Array<ResultSet>> {
+    ): Promise<Array<ResultSet<T>>> {
         this.#checkNotClosed();
         const db = this.#getDb();
         try {
@@ -184,7 +184,7 @@ export class Sqlite3Client implements Client {
                 }
             }
             executeStmt(db, "COMMIT", this.#intMode);
-            return resultSets;
+            return resultSets as Array<ResultSet<T>>;
         } finally {
             if (db.inTransaction) {
                 executeStmt(db, "ROLLBACK", this.#intMode);
@@ -308,13 +308,18 @@ export class Sqlite3Transaction implements Transaction {
         this.#intMode = intMode;
     }
 
-    async execute(stmt: InStatement): Promise<ResultSet>;
-    async execute(sql: string, args?: InArgs): Promise<ResultSet>;
+    async execute<T extends Row = Row>(
+        stmt: InStatement,
+    ): Promise<ResultSet<T>>;
+    async execute<T extends Row = Row>(
+        sql: string,
+        args?: InArgs,
+    ): Promise<ResultSet<T>>;
 
-    async execute(
+    async execute<T extends Row = Row>(
         stmtOrSql: InStatement | string,
         args?: InArgs,
-    ): Promise<ResultSet> {
+    ): Promise<ResultSet<T>> {
         let stmt: InStatement;
 
         if (typeof stmtOrSql === "string") {
@@ -327,12 +332,12 @@ export class Sqlite3Transaction implements Transaction {
         }
 
         this.#checkNotClosed();
-        return executeStmt(this.#database, stmt, this.#intMode);
+        return executeStmt(this.#database, stmt, this.#intMode) as ResultSet<T>;
     }
 
-    async batch(
+    async batch<T extends Row = Row>(
         stmts: Array<InStatement | [string, InArgs?]>,
-    ): Promise<Array<ResultSet>> {
+    ): Promise<Array<ResultSet<T>>> {
         const resultSets = [];
         for (let i = 0; i < stmts.length; i++) {
             try {
@@ -361,7 +366,7 @@ export class Sqlite3Transaction implements Transaction {
                 throw e;
             }
         }
-        return resultSets;
+        return resultSets as Array<ResultSet<T>>;
     }
 
     async executeMultiple(sql: string): Promise<void> {

--- a/packages/libsql-client/src/ws.ts
+++ b/packages/libsql-client/src/ws.ts
@@ -6,6 +6,7 @@ import type {
     Client,
     Transaction,
     ResultSet,
+    Row,
     InStatement,
     InArgs,
     Replicated,
@@ -154,10 +155,10 @@ export class WsClient implements Client {
         return this.#promiseLimitFunction(fn);
     }
 
-    async execute(
+    async execute<T extends Row = Row>(
         stmtOrSql: InStatement | string,
         args?: InArgs,
-    ): Promise<ResultSet> {
+    ): Promise<ResultSet<T>> {
         let stmt: InStatement;
 
         if (typeof stmtOrSql === "string") {
@@ -169,7 +170,7 @@ export class WsClient implements Client {
             stmt = stmtOrSql;
         }
 
-        return this.limit<ResultSet>(async () => {
+        return this.limit<ResultSet<T>>(async () => {
             const streamState = await this.#openStream();
             try {
                 const hranaStmt = stmtToHrana(stmt);
@@ -182,7 +183,7 @@ export class WsClient implements Client {
 
                 const hranaRowsResult = await hranaRowsPromise;
 
-                return resultSetFromHrana(hranaRowsResult);
+                return resultSetFromHrana(hranaRowsResult) as ResultSet<T>;
             } catch (e) {
                 throw mapHranaError(e);
             } finally {
@@ -191,11 +192,11 @@ export class WsClient implements Client {
         });
     }
 
-    async batch(
+    async batch<T extends Row = Row>(
         stmts: Array<InStatement | [string, InArgs?]>,
         mode: TransactionMode = "deferred",
-    ): Promise<Array<ResultSet>> {
-        return this.limit<Array<ResultSet>>(async () => {
+    ): Promise<Array<ResultSet<T>>> {
+        return this.limit<Array<ResultSet<T>>>(async () => {
             const streamState = await this.#openStream();
             try {
                 const normalizedStmts = stmts.map((stmt) => {
@@ -224,7 +225,7 @@ export class WsClient implements Client {
 
                 const results = await resultsPromise;
 
-                return results;
+                return results as Array<ResultSet<T>>;
             } catch (e) {
                 throw mapHranaError(e);
             } finally {

--- a/packages/libsql-core/src/api.ts
+++ b/packages/libsql-core/src/api.ts
@@ -95,8 +95,11 @@ export interface Client {
      * });
      * ```
      */
-    execute(stmt: InStatement): Promise<ResultSet>;
-    execute(sql: string, args?: InArgs): Promise<ResultSet>;
+    execute<T extends Row = Row>(stmt: InStatement): Promise<ResultSet<T>>;
+    execute<T extends Row = Row>(
+        sql: string,
+        args?: InArgs,
+    ): Promise<ResultSet<T>>;
 
     /** Execute a batch of SQL statements in a transaction.
      *
@@ -131,10 +134,10 @@ export interface Client {
      * ], "write");
      * ```
      */
-    batch(
+    batch<T extends Row = Row>(
         stmts: Array<InStatement | [string, InArgs?]>,
         mode?: TransactionMode,
-    ): Promise<Array<ResultSet>>;
+    ): Promise<Array<ResultSet<T>>>;
 
     /** Execute a batch of SQL statements in a transaction with PRAGMA foreign_keys=off; before and PRAGMA foreign_keys=on; after.
      *
@@ -308,14 +311,16 @@ export interface Transaction {
      * });
      * ```
      */
-    execute(stmt: InStatement): Promise<ResultSet>;
+    execute<T extends Row = Row>(stmt: InStatement): Promise<ResultSet<T>>;
 
     /** Execute a batch of SQL statements in this transaction.
      *
      * If any of the statements in the batch fails with an error, further statements are not executed and the
      * returned promise is rejected with an error, but the transaction is not rolled back.
      */
-    batch(stmts: Array<InStatement>): Promise<Array<ResultSet>>;
+    batch<T extends Row = Row>(
+        stmts: Array<InStatement>,
+    ): Promise<Array<ResultSet<T>>>;
 
     /** Execute a sequence of SQL statements separated by semicolons.
      *
@@ -404,7 +409,7 @@ export type TransactionMode = "write" | "read" | "deferred";
  * console.log(`Deleted ${rs.rowsAffected} books`);
  * ```
  */
-export interface ResultSet {
+export interface ResultSet<T extends Row = Row> {
     /** Names of columns.
      *
      * Names of columns can be defined using the `AS` keyword in SQL:
@@ -424,7 +429,7 @@ export interface ResultSet {
     columnTypes: Array<string>;
 
     /** Rows produced by the statement. */
-    rows: Array<Row>;
+    rows: Array<T>;
 
     /** Number of rows that were affected by an UPDATE, INSERT or DELETE operation.
      *


### PR DESCRIPTION
Currently callers have to cast query results to use a concrete type,
which loses type safety when schemas change:

    const book = rs.rows[0] as unknown as Book;

This PR makes ResultSet accept an optional type parameter with a default
of Row, so existing code is completely unaffected. Callers who know the
row shape can now pass it directly:

    const { rows } = await client.execute<Book>("SELECT * FROM books");
    const title: string = rows[0].title;

The same generic is threaded through Client.batch, Transaction.execute,
and Transaction.batch. No runtime behavior changes — the type parameter
is a TypeScript overlay only.

Fixes #218